### PR TITLE
Fix installation of docker-compose on armv7l

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*.swo
+*.swp
+
 .pnpm-debug.log
 .env*
 github.secrets

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -113,8 +113,12 @@ else
   fi
 fi
 
-if ! command -v docker-compose >/dev/null; then
-  sudo curl -L "https://github.com/docker/compose/releases/download/v2.3.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+if ! docker-compose --version >/dev/null; then
+  arch="$(uname -m)"
+  if [[ "$arch" == "armv7l" ]]; then
+    arch="armv7"
+  fi
+  sudo curl -L "https://github.com/docker/compose/releases/download/v2.3.4/docker-compose-$(uname -s)-${arch}" -o /usr/local/bin/docker-compose
   sudo chmod +x /usr/local/bin/docker-compose
 fi
 


### PR DESCRIPTION
On my Raspberry Pi 2 Model B running Raspbian 11, docker-compose failed to install as the binary does not exist at the specified URL. This commit hard-codes an update to the architecture specifically to be passed to the docker-compose URL for the correct installation of docker-compose. Additionally, it adds a check that a docker-compose command can be successfully executed, specifically retrieving the version, as the binary will exist after successful retrieval but will not do the correct thing.

```
$ cat /etc/os-release 
PRETTY_NAME="Raspbian GNU/Linux 11 (bullseye)"
NAME="Raspbian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"
```

```
$ uname -m
armv7l
```