### PR TITLE
fix: Incorrect memory variables

### DIFF
--- a/scripts/system-info.sh
+++ b/scripts/system-info.sh
@@ -13,8 +13,8 @@ USED_DISK_SPACE_BYTES=$(($TOTAL_DISK_SPACE_BYTES - $AVAILABLE_DISK_SPACE_BYTES))
 CPU_LOAD_PERCENTAGE=$(top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1}')
 
 # Memory info
-MEM_TOTAL_BYTES=$(free -b | grep Mem | awk '{print $2}')
-MEM_AVAILABLE_BYTES=$(free -b | grep Mem | awk '{print $7}')
+MEM_TOTAL_BYTES=$(($(cat /proc/meminfo | grep MemTotal |  awk '{print $2}') * 1024))
+MEM_AVAILABLE_BYTES=$(($(cat /proc/meminfo | grep MemAvailable |  awk '{print $2}') * 1024))
 MEM_USED_BYTES=$(($MEM_TOTAL_BYTES - $MEM_AVAILABLE_BYTES))
 
 # Create temporary json file


### PR DESCRIPTION
MEM_TOTAL_BYTES not found for other system languages

like this

<img width="661" alt="image" src="https://user-images.githubusercontent.com/44605072/190616799-ce6f24da-0cac-4282-81bc-14b295c572dd.png">