### PR TITLE
Fully migrate to Docker Compose plugin

### DIFF
--- a/scripts/app.sh
+++ b/scripts/app.sh
@@ -28,7 +28,7 @@ Commands:
     uninstall                  Removes images and destroys all data for an app
     stop                       Stops an installed app
     start                      Starts an installed app
-    compose                    Passes all arguments to docker-compose
+    compose                    Passes all arguments to Docker Compose
     ls-installed               Lists installed apps
 EOF
 }
@@ -129,7 +129,7 @@ compose() {
   export ROOT_FOLDER_HOST="${root_folder_host}"
   export ROOT_FOLDER="${ROOT_FOLDER}"
 
-  # Docker-compose does not support multiple env files
+  # Docker Compose does not support multiple env files
   # --env-file "${env_file}" \
 
   docker-compose \
@@ -209,7 +209,7 @@ if [[ "$command" = "start" ]]; then
   exit
 fi
 
-# Passes all arguments to docker-compose
+# Passes all arguments to Docker Compose
 if [[ "$command" = "compose" ]]; then
   compose "${app}" ${args}
   exit

--- a/scripts/app.sh
+++ b/scripts/app.sh
@@ -132,7 +132,7 @@ compose() {
   # Docker Compose does not support multiple env files
   # --env-file "${env_file}" \
 
-  docker-compose \
+  docker compose \
     --env-file "${ROOT_FOLDER}/app-data/${app}/app.env" \
     --project-name "${app}" \
     --file "${app_compose_file}" \

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -66,6 +66,38 @@ function install_docker() {
   fi
 }
 
+function update_docker() {
+  local os="${1}"
+  echo "Updating Docker for os ${os}" >/dev/tty
+
+  if [[ "${os}" == "debian" ]]; then
+    sudo apt-get update
+    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    return 0
+  elif [[ "${os}" == "ubuntu" || "${os}" == "pop" ]]; then
+    sudo apt-get update
+    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    return 0
+  elif [[ "${os}" == "centos" ]]; then
+    sudo yum install -y --allowerasing docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    return 0
+  elif [[ "${os}" == "fedora" ]]; then
+    sudo dnf -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    return 0
+  elif [[ "${os}" == "arch" ]]; then
+    sudo pacman -Sy --noconfirm docker docker-compose
+
+    if ! command -v crontab >/dev/null; then
+      sudo pacman -Sy --noconfirm cronie
+      systemctl enable --now cronie.service
+    fi
+
+    return 0
+  else
+    return 1
+  fi
+}
+
 function install_jq() {
   local os="${1}"
   echo "Installing jq for os ${os}" >/dev/tty
@@ -92,30 +124,42 @@ OS="$(cat /etc/[A-Za-z]*[_-][rv]e[lr]* | grep "^ID=" | cut -d= -f2 | uniq | tr '
 SUB_OS="$(cat /etc/[A-Za-z]*[_-][rv]e[lr]* | grep "^ID_LIKE=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
 
 if command -v docker >/dev/null; then
-  echo "Docker is already installed"
-else
-  install_docker "${OS}"
+  echo "Docker is already installed, ensuring Docker is fully up to date"
+
+  update_docker "${OS}"
   docker_result=$?
 
   if [[ docker_result -eq 0 ]]; then
-    echo "docker installed"
+    echo "Docker is fully up to date"
   else
     echo "Your system ${OS} is not supported trying with sub_os ${SUB_OS}"
     install_docker "${SUB_OS}"
     docker_sub_result=$?
 
     if [[ docker_sub_result -eq 0 ]]; then
-      echo "docker installed"
+      echo "Docker is fully up to date"
+    else
+      echo "Your system ${SUB_OS} is not supported please update Docker manually"
+      exit 1
+    fi
+else
+  install_docker "${OS}"
+  docker_result=$?
+
+  if [[ docker_result -eq 0 ]]; then
+    echo "Docker installed"
+  else
+    echo "Your system ${OS} is not supported trying with sub_os ${SUB_OS}"
+    install_docker "${SUB_OS}"
+    docker_sub_result=$?
+
+    if [[ docker_sub_result -eq 0 ]]; then
+      echo "Docker installed"
     else
       echo "Your system ${SUB_OS} is not supported please install docker manually"
       exit 1
     fi
   fi
-fi
-
-if ! command -v docker-compose >/dev/null; then
-  sudo curl -L "https://github.com/docker/compose/releases/download/v2.3.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-  sudo chmod +x /usr/local/bin/docker-compose
 fi
 
 if ! command -v jq >/dev/null; then

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -51,7 +51,7 @@ function install_docker() {
     sudo systemctl enable docker
     return 0
   elif [[ "${os}" == "arch" ]]; then
-    sudo pacman -Sy --noconfirm docker
+    sudo pacman -Sy --noconfirm docker docker-compose
     sudo systemctl start docker.service
     sudo systemctl enable docker.service
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -225,16 +225,16 @@ bash "${ROOT_FOLDER}/scripts/system-info.sh"
 if [[ ! $ci == "true" ]]; then
 
   if [[ $rc == "true" ]]; then
-    docker-compose -f docker-compose.rc.yml --env-file "${ROOT_FOLDER}/.env" pull
-    # Run docker-compose
-    docker-compose -f docker-compose.rc.yml --env-file "${ROOT_FOLDER}/.env" up --detach --remove-orphans --build || {
+    docker compose -f docker-compose.rc.yml --env-file "${ROOT_FOLDER}/.env" pull
+    # Run docker compose
+    docker compose -f docker-compose.rc.yml --env-file "${ROOT_FOLDER}/.env" up --detach --remove-orphans --build || {
       echo "Failed to start containers"
       exit 1
     }
   else
-    docker-compose --env-file "${ROOT_FOLDER}/.env" pull
-    # Run docker-compose
-    docker-compose --env-file "${ROOT_FOLDER}/.env" up --detach --remove-orphans --build || {
+    docker compose --env-file "${ROOT_FOLDER}/.env" pull
+    # Run docker compose
+    docker compose --env-file "${ROOT_FOLDER}/.env" up --detach --remove-orphans --build || {
       echo "Failed to start containers"
       exit 1
     }

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -37,4 +37,4 @@ done
 
 echo "Stopping Docker services..."
 echo
-docker-compose down --remove-orphans --rmi local
+docker compose down --remove-orphans --rmi local


### PR DESCRIPTION
 Migrates all Docker Compose commands to the new Docker Compose plugin and ensures it is installed and up to date at each run of start.sh.

This should reduce support tickets around old Docker versions/old Docker Compose versions, and will automatically upgrade anyone still running old versions the next time they run start.sh.