### PR TITLE
Fixing minor issues in start and stop scripts

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -75,7 +75,7 @@ while [ -n "$1" ]; do # while loop starts
 done
 
 # Ensure BASH_SOURCE is ./scripts/start.sh
-if [[ "${BASH_SOURCE[0]}" != "./scripts/start.sh" ]]; then
+if [[ $(basename $(pwd)) != "runtipi" ]] || [[ ! -f "${BASH_SOURCE[0]}" ]]; then
   echo "Please make sure this script is executed from runtipi/"
   exit 1
 fi

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -11,7 +11,7 @@ fi
 if [[ $UID != 0 ]]; then
   echo "Tipi must be stopped as root"
   echo "Please re-run this script as"
-  echo "  sudo ./scripts/stop"
+  echo "  sudo ./scripts/stop.sh"
   exit 1
 fi
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -23,17 +23,21 @@ cd "$ROOT_FOLDER"
 export DOCKER_CLIENT_TIMEOUT=240
 export COMPOSE_HTTP_TIMEOUT=240
 
-# Get all app names from the apps folder
+# Stop all installed apps if there are any
 apps_folder="${ROOT_FOLDER}/apps"
-apps_names=($(ls -d ${apps_folder}/*/ | xargs -n 1 basename | sed 's/\///g'))
+if [ "$(find ${apps_folder} -maxdepth 1 -type d | wc -l)" -gt 1 ]; then
+  apps_names=($(ls -d ${apps_folder}/*/ | xargs -n 1 basename | sed 's/\///g'))
 
-for app_name in "${apps_names[@]}"; do
-  # if folder ${ROOT_FOLDER}/app-data/app_name exists, then stop app
-  if [[ -d "${ROOT_FOLDER}/app-data/${app_name}" ]]; then
-    echo "Stopping ${app_name}"
-    "${ROOT_FOLDER}/scripts/app.sh" stop $app_name
-  fi
-done
+  for app_name in "${apps_names[@]}"; do
+    # if folder ${ROOT_FOLDER}/app-data/app_name exists, then stop app
+    if [[ -d "${ROOT_FOLDER}/app-data/${app_name}" ]]; then
+      echo "Stopping ${app_name}"
+      "${ROOT_FOLDER}/scripts/app.sh" stop $app_name
+    fi
+  done
+else
+  echo "No app installed that can be stopped."
+fi
 
 echo "Stopping Docker services..."
 echo


### PR DESCRIPTION
Fixing two minor issues I had using start and stop scripts

## start.sh

* Now checks if the current working directory is `runtipi` and makes sure the referenced script (scripts/start.sh) exists. Before, you had to run the script using `sudo ./scripts/start.sh` exactly like that. Running `sudo scripts/start.sh` (note the missing ./) failed due to a wrong check for `./scripts/start.sh`. This is not fixed.

## stop.sh

* Now checks if the apps directory contains sub directories before accessing `apps/*/`. The latter throws an error for the case there is no sub directory and stopping runtipi fails.
* Added missing `.sh` in 'please run as root' note.