### PR TITLE
start.sh - choose between network interfaces

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -97,6 +97,25 @@ STATE_FOLDER="${ROOT_FOLDER}/state"
 SED_ROOT_FOLDER="$(echo $ROOT_FOLDER | sed 's/\//\\\//g')"
 
 NETWORK_INTERFACE="$(ip route | grep default | awk '{print $5}' | uniq)"
+NETWORK_INTERFACE_COUNT=$(echo "$NETWORK_INTERFACE" | wc -l)
+
+if [[ "$NETWORK_INTERFACE_COUNT" -eq 0 ]]; then
+  echo "No network interface found!"
+  exit 1
+elif [[ "$NETWORK_INTERFACE_COUNT" -gt 1 ]]; then
+  echo "Found multiple network interfaces. Please select one of the following interfaces:"
+  echo "$NETWORK_INTERFACE"
+  while true; do
+    read -p "> " USER_NETWORK_INTERFACE
+    if echo "$NETWORK_INTERFACE" | grep -x "$USER_NETWORK_INTERFACE"; then
+      NETWORK_INTERFACE="$USER_NETWORK_INTERFACE"
+      break
+    else
+      echo "Please select one of the interfaces above. (CTRL+C to abort)"
+    fi
+  done
+fi
+
 INTERNAL_IP="$(ip addr show "${NETWORK_INTERFACE}" | grep "inet " | awk '{print $2}' | cut -d/ -f1)"
 DNS_IP=9.9.9.9 # Default to Quad9 DNS
 ARCHITECTURE="$(uname -m)"


### PR DESCRIPTION
Offers option to choose between network interfaces for the case multiple defaults were found

Looks like this:
![image](https://user-images.githubusercontent.com/11060652/191600753-243b005f-7ca3-4edb-9f9f-81418b9320e6.png)
1. Prints available default network interfaces
2. Prompt to choose between interfaces
3. Error handling for not existing interfaces
4. Overwrites the existing variable `NETWORK_INTERFACE` --> Everything after follows the process as intended

Also handles the very unlikely case of 0 available default network interfaces.

Fixes https://github.com/meienberger/runtipi/issues/210