### PR TITLE
fix: Use postgres:14 instead of postgres:latest 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:latest
+        image: postgres:14
         env:
           POSTGRES_PASSWORD: postgres
         ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,7 +20,7 @@ services:
 
   tipi-db:
     container_name: tipi-db
-    image: postgres:latest
+    image: postgres:14
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/docker-compose.rc.yml
+++ b/docker-compose.rc.yml
@@ -19,7 +19,7 @@ services:
 
   tipi-db:
     container_name: tipi-db
-    image: postgres:latest
+    image: postgres:14
     restart: on-failure
     stop_grace_period: 1m
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   tipi-db:
     container_name: tipi-db
-    image: postgres:latest
+    image: postgres:14
     restart: on-failure
     stop_grace_period: 1m
     volumes:


### PR DESCRIPTION
Use postgres:14 instead of postgres:latest (which resolves to postgres:15) because of a database version incompatibility error. This resolves #242 so master works again, however a better fix would be to upgrade from postgres 14 to 15.

Also, I made this change in the GitHub Workflow but I'm not sure if this is necessary or wanted.