### PR TITLE
feat: install through bash script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,25 @@ You can try out a demo of Tipi at [demo.runtipi.com](demo.runtipi.com) using the
 
 Ubuntu 18.04 LTS or higher is recommended. However other major Linux distribution are supported but may lead to installation issues. Please file an issue if you encounter one.
 
-### Step 1. Download Tipi
+### Download and install Tipi
 
-Download the latest version of Tipi from GitHub:
+Download the latest version of Tipi:
 
 ```bash
-git clone https://github.com/meienberger/runtipi.git
+curl -L https://setup.runtipi.com | bash
 ```
 
-### Step 2. Run Tipi
+The script will prompt you the ip address of the dashboard once configured.
 
-Navigate to the downloaded directory and run the `start.sh` script to start Tipi:
+### Commands
+
+If you already installed Tipi, you can start it manually by running the `start.sh` script in the `runtipi` folder.
 
 ```bash
 cd runtipi
 sudo ./scripts/start.sh
 ```
 
-The script will prompt you the ip address of the dashboard once configured.
 Tipi will run by default on port 80. To select another port you can run the start script with the `--port` argument
 
 ```bash
@@ -68,9 +69,17 @@ To stop Tipi, run the stop script.
 sudo ./scripts/stop.sh
 ```
 
+### Update Tipi
+
+To update Tipi to the latest version, run the update script.
+
+```bash
+sudo ./scripts/system.sh update
+```
+
 ### Custom settings
 
-You can change the default settings by creating a `settings.json` file. The file should be located in the `state` directory. This file will make your changes persist across restarts. Example file:
+You can change the default settings by creating a `settings.json` file. The file should be located in the `runtipi/state` directory. This file will make your changes persist across restarts. Example file:
 
 ```json
 {

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -103,27 +103,7 @@ function update_docker() {
   fi
 }
 
-if command -v docker >/dev/null; then
-  echo "Docker is already installed, ensuring Docker is fully up to date"
-
-  update_docker "${OS}"
-  docker_result=$?
-
-  if [[ docker_result -eq 0 ]]; then
-    echo "Docker is fully up to date"
-  else
-    echo "Your system ${OS} is not supported trying with sub_os ${SUB_OS}"
-    install_docker "${SUB_OS}"
-    docker_sub_result=$?
-
-    if [[ docker_sub_result -eq 0 ]]; then
-      echo "Docker is fully up to date"
-    else
-      echo "Your system ${SUB_OS} is not supported please update Docker manually"
-      exit 1
-    fi
-  fi
-else
+if ! command -v docker >/dev/null; then
   install_docker "${OS}"
   docker_result=$?
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Installing runtipi..."
+LATEST_VERSION=$(curl -s https://api.github.com/repos/meienberger/runtipi/releases/latest | grep tag_name | cut -d '"' -f4)
+
+### --------------------------------
+### CLI arguments
+### --------------------------------
+UPDATE="false"
+while [ -n "${1-}" ]; do
+    case "$1" in
+    --update) UPDATE="true" ;;
+    --)
+        shift # The double dash makes them parameters
+        break
+        ;;
+    *) echo "Option $1 not recognized" && exit 1 ;;
+    esac
+    shift
+done
+
+if [[ "${UPDATE}" == "false" ]]; then
+    mkdir -p runtipi
+    cd runtipi || exit
+fi
+
+curl --location https://api.github.com/repos/meienberger/runtipi/tarball/"${LATEST_VERSION}" -o runtipi.tar.gz
+mkdir runtipi-"${LATEST_VERSION}"
+tar -xzf runtipi.tar.gz -C runtipi-"${LATEST_VERSION}" --strip-components=1
+rm runtipi.tar.gz
+
+# copy from downloaded /scripts/*
+if [ -d "scripts" ]; then
+    rm -rf scripts
+fi
+mkdir scripts
+cp -r runtipi-"${LATEST_VERSION}"/scripts/* ./scripts
+
+# copy from downloaded /templates/*
+if [ -d "templates" ]; then
+    rm -rf templates
+fi
+mkdir templates
+cp -r runtipi-"${LATEST_VERSION}"/templates/* ./templates
+
+# copy from downloaded /traefik/*
+if [ -d "traefik" ]; then
+    rm -rf traefik
+fi
+mkdir traefik
+cp -r runtipi-"${LATEST_VERSION}"/traefik/* ./traefik
+
+# copy from downloaded /docker-compose.yml
+if [ -f "docker-compose.yml" ]; then
+    rm -f docker-compose.yml
+fi
+cp -r runtipi-"${LATEST_VERSION}"/docker-compose.yml .
+
+# copy from downloaded /package.json
+if [ -f "package.json" ]; then
+    rm -f package.json
+fi
+cp -r runtipi-"${LATEST_VERSION}"/package.json .
+
+mkdir -p state
+## remove downloaded folder
+rm -rf runtipi-"${LATEST_VERSION}"
+
+sudo ./scripts/start.sh

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -25,7 +25,9 @@ STATE_FOLDER="${ROOT_FOLDER}/state"
 # Create seed file with cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1
 if [[ ! -f "${STATE_FOLDER}/seed" ]]; then
   echo "Generating seed..."
-  tr </dev/urandom -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 >"${STATE_FOLDER}/seed"
+  if ! tr </dev/urandom -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 >"${STATE_FOLDER}/seed"; then
+    echo "Created seed file..."
+  fi
 fi
 
 ### --------------------------------

--- a/scripts/system.sh
+++ b/scripts/system.sh
@@ -11,23 +11,56 @@ else
     command="$1"
 fi
 
-# Restart Tipi
-if [[ "$command" = "restart" ]]; then
+function update() {
+    write_log "Updating Tipi..."
+
+    local current_version=$(get_json_field "${ROOT_FOLDER}/package.json" version)
+    # check latest version
+    local latest=$(curl -s https://api.github.com/repos/meienberger/runtipi/releases/latest | grep tag_name | cut -d '"' -f4)
+
+    scripts/stop.sh
+
+    # backup current version to backups/${current_version}/
+    local timestamp=$(date +%s)
+    local backup_folder="${ROOT_FOLDER}/backups/${current_version}-${timestamp}"
+
+    mkdir -p "${backup_folder}"
+    cp -r "${ROOT_FOLDER}/scripts" "${backup_folder}"
+    cp -r "${ROOT_FOLDER}/templates" "${backup_folder}"
+    cp -r "${ROOT_FOLDER}/traefik" "${backup_folder}"
+    cp -r "${ROOT_FOLDER}/package.json" "${backup_folder}"
+    cp -r "${ROOT_FOLDER}/docker-compose.yml" "${backup_folder}"
+
+    # download install.sh from latest release to install-${latest_version}.sh
+    curl -L https://raw.githubusercontent.com/meienberger/runtipi/master/scripts/install.sh >install-"${latest}".sh
+
+    chmod +x ./install-"${latest}".sh
+    # run install-${latest_version}.sh
+    ./install-"${latest}".sh --update
+
+    # remove install-${latest_version}.sh
+    rm install-"${latest}".sh
+    rm -rf runtipi-"${latest}"
+    rm -rf runtipi.tar.gz
+
+    exit 0
+}
+
+function restart() {
     write_log "Restarting Tipi..."
 
     scripts/stop.sh
     scripts/start.sh
 
     exit
+}
+
+# Restart Tipi
+if [[ "$command" = "restart" ]]; then
+    restart
 fi
 
 # Update Tipi
 if [[ "$command" = "update" ]]; then
-    write_log "Updating Tipi..."
-
-    scripts/stop.sh
-    git config --global --add safe.directory "${ROOT_FOLDER}"
-    git pull origin "$(git rev-parse --abbrev-ref HEAD)"
-    scripts/start.sh
-    exit
+    update
 fi

--- a/templates/config-sample.json
+++ b/templates/config-sample.json
@@ -1,3 +1,0 @@
-{
-  "repo": "https://github.com/meienberger/runtipi-appstore"
-}


### PR DESCRIPTION
### Purpose

Add the possibility to install Tipi using just one curl command.

```
curl -L https://setup.runtipi.com | bash
```

This will provide an easier installation/update flow by avoiding using `git clone` and `git pull`

### Changes

- New `install.sh` script which downloads the latest version and replace the files.
- Update `system.sh` to download latest install script from github and to create a backup of the previous config in case of failure
- Remove the update docker on each start in configure script
- Update README
