### PR TITLE
Adding config for codespaces [skip ci]

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker": {
+      "version": "latest",
+      "moby": true
+    }
+  },
+  "extensions": [
+    "ms-azuretools.vscode-docker",
+    "ms-vscode.vscode-typescript-next",
+    "waderyan.gitblame"
+  ],
+  "postCreateCommand": "./.devcontainer/postCreateCommand.sh"
+}

--- a/.devcontainer/filewatcher.sh
+++ b/.devcontainer/filewatcher.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# We need to change the owner of the files in the app-data folder
+# if this failes we have to change the permission your self
+fswatch --event=Created /workspaces/runtipi/app-data/ | \
+   xargs -l1 sh -c 'echo "$1" && sudo chown node "$1" -R' -- &

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+echo '{ 
+    "appsRepoUrl": "https://github.com/meienberger/runtipi-appstore.git/"
+}' > state/settings.json
+npm i -g pnpm
+pnpm i
+sudo apt-get update
+sudo apt-get install jq fswatch -y
+mkdir logs
+mkdir data
+sudo chown node logs
+sudo chown node data 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "act:test-install": "act --container-architecture linux/amd64 -j test-install",
     "act:docker": "act --container-architecture linux/amd64 --secret-file github.secrets -j build-images",
     "start:dev": "./scripts/start-dev.sh",
+    "start:dev-container": "./.devcontainer/filewatcher.sh && npm run start:dev",
     "start:rc": "docker-compose -f docker-compose.rc.yml --env-file .env up --build",
     "start:prod": "docker-compose -f docker-compose.test.yml --env-file .env up --build",
     "start:pg": "docker run --name test-db -p 5433:5432 -d --rm -e POSTGRES_PASSWORD=postgres postgres",


### PR DESCRIPTION
With this PR you can start Tipi in GitHub Codespaces (aka. devcontainers). You don’t need to install dependencies in it. GitHub gives you [60 hours](https://github.blog/changelog/2022-11-09-codespaces-for-free-and-pro-accounts/) of run time for a 2 core codespace, plus 15 GB of storage to use each month for free.

# Documentation 
> Should be a new heading in Running for development
> 

## Codespaces

The easiest way to start developing on Tipi is to use GitHub Codespaces. All dependency are already installed, you don’t need to set up anything extra. But there are a few things to consider developing in Codespaces. 

After the Codespaces is created, and you are faced with the IDE, you can start Tipi with `npm run start:dev-container`. This is necessary because we have to start an extra script to handle permissions inside the Codespaces. This first start will take a while, this is normal. 

---

> Should be after 7, in Adding your own app
> 

## Testing your application

Create a Tipi Codespace and change the app-repo URL in `state/settings.json`. Start Tipi with `npm run start:dev-container` go to the port tab, and open the dashboard (port 3000). Create a quick account on the dashboard, and start your new application, you will find it on the app-store. If there were errors in your app configuration, they will be shown up. If you cannot solve them by your own, feel free to ask on discord.