### PR TITLE
refactor: remove prisma from context and use client directly in service

### DIFF
--- a/packages/dashboard/src/server/context.ts
+++ b/packages/dashboard/src/server/context.ts
@@ -1,7 +1,6 @@
 import { inferAsyncReturnType } from '@trpc/server';
 import { CreateNextContextOptions } from '@trpc/server/adapters/next';
 import { getServerAuthSession } from './common/get-server-auth-session';
-import { prisma } from './db/client';
 
 type Session = {
   userId?: number;
@@ -19,7 +18,6 @@ type CreateContextOptions = {
  * */
 export const createContextInner = async (opts: CreateContextOptions) => ({
   session: opts.session,
-  prisma,
 });
 
 /**

--- a/packages/dashboard/src/server/routers/auth/auth.router.ts
+++ b/packages/dashboard/src/server/routers/auth/auth.router.ts
@@ -3,10 +3,10 @@ import AuthService from '../../services/auth/auth.service';
 import { router, publicProcedure, protectedProcedure } from '../../trpc';
 
 export const authRouter = router({
-  login: publicProcedure.input(z.object({ username: z.string(), password: z.string() })).mutation(async ({ ctx, input }) => AuthService.login({ ...input }, ctx)),
+  login: publicProcedure.input(z.object({ username: z.string(), password: z.string() })).mutation(async ({ input }) => AuthService.login({ ...input })),
   logout: protectedProcedure.mutation(async ({ ctx }) => AuthService.logout(ctx.session.id)),
-  register: publicProcedure.input(z.object({ username: z.string(), password: z.string() })).mutation(async ({ ctx, input }) => AuthService.register({ ...input }, ctx)),
+  register: publicProcedure.input(z.object({ username: z.string(), password: z.string() })).mutation(async ({ input }) => AuthService.register({ ...input })),
   refreshToken: protectedProcedure.mutation(async ({ ctx }) => AuthService.refreshToken(ctx.session.id)),
-  me: publicProcedure.query(async ({ ctx }) => AuthService.me(ctx)),
-  isConfigured: publicProcedure.query(async ({ ctx }) => AuthService.isConfigured(ctx)),
+  me: publicProcedure.query(async ({ ctx }) => AuthService.me(ctx.session?.userId)),
+  isConfigured: publicProcedure.query(async () => AuthService.isConfigured()),
 });


### PR DESCRIPTION
No need to use Prisma from context, as it can be simply imported in service files. This simplifies code and tests