### PR TITLE
fix: client not showing latest app updates 

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -101,6 +101,7 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "4.9.4",
+    "wait-for-expect": "^3.0.2",
     "whatwg-fetch": "^3.6.2"
   },
   "msw": {

--- a/packages/dashboard/src/client/mocks/fixtures/app.fixtures.ts
+++ b/packages/dashboard/src/client/mocks/fixtures/app.fixtures.ts
@@ -54,6 +54,8 @@ export const createAppEntity = (params: CreateAppEntityParams): AppWithInfo => {
     numOpened: 0,
     createdAt: faker.date.past(),
     updatedAt: faker.date.past(),
+    latestVersion: 1,
+    latestDockerVersion: '1.0.0',
     ...overrides,
   };
 };

--- a/packages/dashboard/src/client/modules/Apps/containers/AppDetailsContainer/AppDetailsContainer.test.tsx
+++ b/packages/dashboard/src/client/modules/Apps/containers/AppDetailsContainer/AppDetailsContainer.test.tsx
@@ -19,7 +19,7 @@ describe('Test: AppDetailsContainer', () => {
 
     it('should display update button when update is available', async () => {
       // Arrange
-      const app = createAppEntity({ overrides: { version: 2 }, overridesInfo: { tipi_version: 3 } });
+      const app = createAppEntity({ overrides: { version: 2, latestVersion: 3 } });
       render(<AppDetailsContainer app={app} />);
 
       // Assert
@@ -173,7 +173,7 @@ describe('Test: AppDetailsContainer', () => {
   describe('Test: Update app', () => {
     it('should display toast success when update success', async () => {
       // Arrange
-      const app = createAppEntity({ overrides: { version: 2 }, overridesInfo: { tipi_version: 3 } });
+      const app = createAppEntity({ overrides: { version: 2, latestVersion: 3 } });
       server.use(getTRPCMock({ path: ['app', 'updateApp'], type: 'mutation', response: app }));
       const { result } = renderHook(() => useToastStore());
       render(<AppDetailsContainer app={app} />);
@@ -195,7 +195,7 @@ describe('Test: AppDetailsContainer', () => {
       // Arrange
       const { result } = renderHook(() => useToastStore());
       server.use(getTRPCMockError({ path: ['app', 'updateApp'], type: 'mutation', message: 'my big error' }));
-      const app = createAppEntity({ overrides: { version: 2 }, overridesInfo: { tipi_version: 3 } });
+      const app = createAppEntity({ overrides: { version: 2, latestVersion: 3 }, overridesInfo: { tipi_version: 3 } });
       render(<AppDetailsContainer app={app} />);
 
       // Act

--- a/packages/dashboard/src/client/modules/Apps/containers/AppDetailsContainer/AppDetailsContainer.tsx
+++ b/packages/dashboard/src/client/modules/Apps/containers/AppDetailsContainer/AppDetailsContainer.tsx
@@ -105,7 +105,7 @@ export const AppDetailsContainer: React.FC<IProps> = ({ app }) => {
     onError: (e) => addToast({ title: 'Update error', description: e.message, status: 'error' }),
   });
 
-  const updateAvailable = Number(app?.version || 0) < Number(app?.info.tipi_version);
+  const updateAvailable = Number(app.version || 0) < Number(app?.latestVersion || 0);
 
   const handleInstallSubmit = async (values: FormValues) => {
     const { exposed, domain, ...form } = values;
@@ -144,7 +144,7 @@ export const AppDetailsContainer: React.FC<IProps> = ({ app }) => {
     }
   };
 
-  const newVersion = [app?.info.version ? `${app?.info.version}` : '', `(${String(app?.info.tipi_version)})`].join(' ');
+  const newVersion = [app?.latestDockerVersion ? `${app?.latestDockerVersion}` : '', `(${String(app?.latestVersion)})`].join(' ');
 
   return (
     <div className="card" data-testid="app-details">

--- a/packages/dashboard/src/client/modules/Apps/pages/AppsPage/AppsPage.tsx
+++ b/packages/dashboard/src/client/modules/Apps/pages/AppsPage/AppsPage.tsx
@@ -12,7 +12,7 @@ export const AppsPage: NextPage = () => {
   const { data, isLoading, error } = trpc.app.installedApps.useQuery();
 
   const renderApp = (app: AppRouterOutput['installedApps'][number]) => {
-    const updateAvailable = Number(app.version) < Number(app.info.tipi_version);
+    const updateAvailable = Number(app.version) < Number(app.latestVersion);
 
     if (app.info?.available) return <AppTile key={app.id} app={app.info} status={app.status} updateAvailable={updateAvailable} />;
 

--- a/packages/dashboard/src/server/services/apps/apps.helpers.test.ts
+++ b/packages/dashboard/src/server/services/apps/apps.helpers.test.ts
@@ -403,33 +403,26 @@ describe('getUpdateInfo', () => {
   });
 
   it('Should return update info', async () => {
-    const updateInfo = await getUpdateInfo(app1.id, 1);
+    const updateInfo = getUpdateInfo(app1.id);
 
-    expect(updateInfo?.latest).toBe(app1.tipi_version);
-    expect(updateInfo?.current).toBe(1);
+    expect(updateInfo?.latestVersion).toBe(app1.tipi_version);
   });
 
-  it('Should return null if app is not installed', async () => {
-    const updateInfo = await getUpdateInfo(faker.random.word(), 1);
+  it('Should return default values if app is not installed', async () => {
+    const updateInfo = getUpdateInfo(faker.random.word());
 
-    expect(updateInfo).toBeNull();
+    expect(updateInfo).toEqual({ latestVersion: 0, latestDockerVersion: '0.0.0' });
   });
 
-  it('Should return null if config.json is invalid', async () => {
+  it('Should return default values if config.json is invalid', async () => {
     const { appInfo, MockFiles } = await createApp({ installed: true }, db);
     MockFiles[`/runtipi/repos/repo-id/apps/${appInfo.id}/config.json`] = 'invalid json';
     // @ts-expect-error - Mocking fs
     fs.__createMockFiles(MockFiles);
 
-    const updateInfo = await getUpdateInfo(appInfo.id, 1);
+    const updateInfo = getUpdateInfo(appInfo.id);
 
-    expect(updateInfo).toBeNull();
-  });
-
-  it('should return null if version is not provided', async () => {
-    const updateInfo = await getUpdateInfo(app1.id);
-
-    expect(updateInfo).toBe(null);
+    expect(updateInfo).toEqual({ latestVersion: 0, latestDockerVersion: '0.0.0' });
   });
 });
 

--- a/packages/dashboard/src/server/services/apps/apps.helpers.ts
+++ b/packages/dashboard/src/server/services/apps/apps.helpers.ts
@@ -242,6 +242,30 @@ export const getAvailableApps = async () => {
 };
 
 /**
+ *  This function returns an object containing information about the updates available for the app with the provided id.
+ *  It checks if the app is installed or not and looks for the config.json file in the appropriate directory.
+ *  If the config.json file is invalid, it returns null.
+ *  If the app is not found, it returns null.
+ *
+ *  @param {string} id - The app id.
+ *  @param {number} [version] - The current version of the app.
+ *  @returns {Promise<{current: number, latest: number, dockerVersion: string} | null>} - Returns an object containing information about the updates available for the app or null if the app is not found or has an invalid config.json file.
+ */
+export const getUpdateInfo = (id: string) => {
+  const repoConfig = readJsonFile(`/runtipi/repos/${getConfig().appsRepoId}/apps/${id}/config.json`);
+  const parsedConfig = appInfoSchema.safeParse(repoConfig);
+
+  if (parsedConfig.success) {
+    return {
+      latestVersion: parsedConfig.data.tipi_version,
+      latestDockerVersion: parsedConfig.data.version,
+    };
+  }
+
+  return { latestVersion: 0, latestDockerVersion: '0.0.0' };
+};
+
+/**
  *  This function reads the config.json and metadata/description.md files for the app with the provided id,
  *  parses the config file and returns an object with app information.
  *  It checks if the app is installed or not and looks for the config.json file in the appropriate directory.
@@ -282,37 +306,6 @@ export const getAppInfo = (id: string, status?: App['status']) => {
     Logger.error(`Error loading app: ${id}`);
     throw new Error(`Error loading app: ${id}`);
   }
-};
-
-/**
- *  This function returns an object containing information about the updates available for the app with the provided id.
- *  It checks if the app is installed or not and looks for the config.json file in the appropriate directory.
- *  If the config.json file is invalid, it returns null.
- *  If the app is not found, it returns null.
- *
- *  @param {string} id - The app id.
- *  @param {number} [version] - The current version of the app.
- *  @returns {Promise<{current: number, latest: number, dockerVersion: string} | null>} - Returns an object containing information about the updates available for the app or null if the app is not found or has an invalid config.json file.
- */
-export const getUpdateInfo = async (id: string, version?: number) => {
-  const doesFileExist = fileExists(`/runtipi/repos/${getConfig().appsRepoId}/apps/${id}`);
-
-  if (!doesFileExist || !version) {
-    return null;
-  }
-
-  const repoConfig = readJsonFile(`/runtipi/repos/${getConfig().appsRepoId}/apps/${id}/config.json`);
-  const parsedConfig = appInfoSchema.safeParse(repoConfig);
-
-  if (parsedConfig.success) {
-    return {
-      current: version || 0,
-      latest: parsedConfig.data.tipi_version,
-      dockerVersion: parsedConfig.data.version,
-    };
-  }
-
-  return null;
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,7 @@ importers:
       typescript: 4.9.4
       uuid: ^9.0.0
       validator: ^13.7.0
+      wait-for-expect: ^3.0.2
       whatwg-fetch: ^3.6.2
       winston: ^3.7.2
       zod: ^3.19.1
@@ -189,6 +190,7 @@ importers:
       ts-jest: 29.0.3_iyz3vhhlowkpp2xbqliblzwv3y
       ts-node: 10.9.1_awa2wsr5thmg3i7jqycphctjfq
       typescript: 4.9.4
+      wait-for-expect: 3.0.2
       whatwg-fetch: 3.6.2
 
   packages/system-api:
@@ -11304,6 +11306,10 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       xml-name-validator: 4.0.0
+    dev: true
+
+  /wait-for-expect/3.0.2:
+    resolution: {integrity: sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==}
     dev: true
 
   /walker/1.0.8:


### PR DESCRIPTION
## Purpose
There is a bug in which the client is not receiving the update info correctly. The info is always taken from the installed app files.

## Changes
- Add two new fields `latestVersion` and `latestDockerVersion` to the app
- Change frontend to use those fields instead of app info
- Increase test coverage for apps service