### PR TITLE
User persistent docker-compose files

### DIFF
--- a/scripts/app.sh
+++ b/scripts/app.sh
@@ -83,6 +83,18 @@ compose() {
 
   local common_compose_file="${ROOT_FOLDER}/repos/${REPO_ID}/apps/docker-compose.common.yml"
 
+  local user_compose_file="${ROOT_FOLDER}/user-config/${app}/docker-compose.yml"
+  local user_compose_args=
+  if [[ -f ${user_compose_file} ]]; then
+    user_compose_args="--file ${user_compose_file}"
+  fi
+
+  local user_env_file="${ROOT_FOLDER}/user-config/${app}/app.env"
+  local user_env_args=
+  if [[ -f ${user_env_file} ]]; then
+    user_env_args="--env-file ${user_env_file}"
+  fi
+
   # Vars to use in compose file
   export APP_DATA_DIR="${STORAGE_PATH}/app-data/${app}"
   export ROOT_FOLDER_HOST="${ROOT_FOLDER_HOST}"
@@ -93,9 +105,11 @@ compose() {
 
   docker compose \
     --env-file "${app_data_dir}/app.env" \
+    ${user_env_args} \
     --project-name "${app}" \
     --file "${app_compose_file}" \
     --file "${common_compose_file}" \
+    ${user_compose_args} \
     "${@}"
 }
 


### PR DESCRIPTION
Relates to #311 

I create a docker-compose in the runtipi folder that mounts my `/cellar` volume:
```
# runtipi/docker-compose.filebrowser.yml
version: "3.7"
services:
  filebrowser:
    volumes:
      - /cellar:/srv/cellar
```

Filebrowser gets the volume:
```
PS ❯ $fb = docker inspect filebrowser | ConvertFrom-Json; $fb.Mounts | ft

Type   Source                                                                                         Destination   Mode   RW Propagation
----   ------                                                                                         -----------   ----   -- -----------
bind   /usr/bin/runtipi/app-data/filebrowser/data/db                                                  /database     rw   True rprivate
bind   /usr/bin/runtipi/app-data                                                                      /srv/app-data rw   True rprivate
bind   /cellar                                                                                        /srv/cellar   rw   True rprivate
bind   /usr/bin/runtipi/media                                                                         /srv/media    rw   True rprivate
volume /var/lib/docker/volumes/455f7ddd0802ea8527b3556a92b7bf8e26ab714eea27f7d9584528a1834d545d/_data /srv          z    True
bind   /usr/bin/runtipi/app-data/filebrowser/data/config                                              /config       rw   True rprivate
```

The web app shows my volume:
![image](https://user-images.githubusercontent.com/3678789/220473291-343fd81a-92ab-4d47-8a40-767a41c9dcab.png)

Note that my pihole app, whcih does not have a user docker-compose, is unaffected.