### PR TITLE
fix(dashboard): only check status if restart or update has been requested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,14 +49,13 @@ logs
 !.env.test
 github.secrets
 node_modules/
-app-data
-data
-data
-repos
-apps
+/app-data/
+/data/
+/repos/
+/apps/
 traefik/shared
 
 # media folder
 media
 
-state
+/state/

--- a/src/client/components/hoc/StatusProvider/StatusProvider.tsx
+++ b/src/client/components/hoc/StatusProvider/StatusProvider.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect, useRef } from 'react';
 import router from 'next/router';
-import {  useSystemStore } from '../../../state/systemStore';
+import { useSystemStore } from '../../../state/systemStore';
 import { StatusScreen } from '../../StatusScreen';
 
 interface IProps {
@@ -8,12 +8,13 @@ interface IProps {
 }
 
 export const StatusProvider: React.FC<IProps> = ({ children }) => {
-  const { status } = useSystemStore();
+  const { status, setPollStatus } = useSystemStore();
   const s = useRef(status);
 
   useEffect(() => {
     // If previous was not running and current is running, we need to refresh the page
     if (status === 'RUNNING' && s.current !== 'RUNNING') {
+      setPollStatus(false);
       router.reload();
     }
     if (status === 'RUNNING') {
@@ -25,7 +26,7 @@ export const StatusProvider: React.FC<IProps> = ({ children }) => {
     if (status === 'UPDATING') {
       s.current = 'UPDATING';
     }
-  }, [status, s]);
+  }, [status, s, setPollStatus]);
 
   if (s.current === 'LOADING') {
     return <StatusScreen title="" subtitle="" />;

--- a/src/client/modules/Apps/components/InstallForm/InstallForm.tsx
+++ b/src/client/modules/Apps/components/InstallForm/InstallForm.tsx
@@ -28,7 +28,7 @@ export const InstallForm: React.FC<IProps> = ({ formFields, onSubmit, initalValu
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isDirty },
     setValue,
     watch,
     setError,
@@ -36,12 +36,12 @@ export const InstallForm: React.FC<IProps> = ({ formFields, onSubmit, initalValu
   const watchExposed = watch('exposed', false);
 
   useEffect(() => {
-    if (initalValues) {
+    if (initalValues && !isDirty) {
       Object.entries(initalValues).forEach(([key, value]) => {
         setValue(key, value);
       });
     }
-  }, [initalValues, setValue]);
+  }, [initalValues, isDirty, setValue]);
 
   const renderField = (field: FormField) => (
     <Input

--- a/src/client/modules/Settings/containers/SettingsContainer/SettingsContainer.tsx
+++ b/src/client/modules/Settings/containers/SettingsContainer/SettingsContainer.tsx
@@ -7,6 +7,7 @@ import { useToastStore } from '../../../../state/toastStore';
 import { RestartModal } from '../../components/RestartModal';
 import { UpdateModal } from '../../components/UpdateModal/UpdateModal';
 import { trpc } from '../../../../utils/trpc';
+import { useSystemStore } from '../../../../state/systemStore';
 
 type IProps = { data: SystemRouterOutput['getVersion'] };
 
@@ -14,6 +15,7 @@ export const SettingsContainer: React.FC<IProps> = ({ data }) => {
   const [loading, setLoading] = React.useState(false);
   const { current, latest } = data;
   const { addToast } = useToastStore();
+  const { setPollStatus } = useSystemStore();
   const restartDisclosure = useDisclosure();
   const updateDisclosure = useDisclosure();
 
@@ -26,6 +28,7 @@ export const SettingsContainer: React.FC<IProps> = ({ data }) => {
     },
     onSuccess: async () => {
       setLoading(false);
+      setPollStatus(true);
       localStorage.removeItem('token');
     },
     onError: (error) => {
@@ -41,7 +44,7 @@ export const SettingsContainer: React.FC<IProps> = ({ data }) => {
     },
     onSuccess: async () => {
       setLoading(false);
-
+      setPollStatus(true);
       localStorage.removeItem('token');
     },
     onError: (error) => {

--- a/src/client/state/systemStore.ts
+++ b/src/client/state/systemStore.ts
@@ -10,14 +10,18 @@ export type SystemStatus = (typeof SYSTEM_STATUS)[keyof typeof SYSTEM_STATUS];
 
 type Store = {
   status: SystemStatus;
+  pollStatus: boolean;
   version: { current: string; latest?: string };
   setStatus: (status: SystemStatus) => void;
   setVersion: (version: { current: string; latest?: string }) => void;
+  setPollStatus: (pollStatus: boolean) => void;
 };
 
 export const useSystemStore = create<Store>((set) => ({
   status: 'RUNNING',
   version: { current: '0.0.0', latest: '0.0.0' },
+  pollStatus: false,
   setStatus: (status: SystemStatus) => set((state) => ({ ...state, status })),
   setVersion: (version: { current: string; latest?: string }) => set((state) => ({ ...state, version })),
+  setPollStatus: (pollStatus: boolean) => set((state) => ({ ...state, pollStatus })),
 }));

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,9 +14,9 @@ import { SystemStatus, useSystemStore } from '../client/state/systemStore';
 
 function MyApp({ Component, pageProps }: AppProps) {
   const { setDarkMode } = useUIStore();
-  const { setStatus, setVersion } = useSystemStore();
+  const { setStatus, setVersion, pollStatus } = useSystemStore();
 
-  trpc.system.status.useQuery(undefined, { networkMode: 'online', refetchInterval: 5000, onSuccess: (d) => setStatus((d.status as SystemStatus) || 'RUNNING') });
+  trpc.system.status.useQuery(undefined, { networkMode: 'online', refetchInterval: 2000, onSuccess: (d) => setStatus((d.status as SystemStatus) || 'RUNNING'), enabled: pollStatus });
   const version = trpc.system.getVersion.useQuery(undefined, { networkMode: 'online' });
 
   useEffect(() => {

--- a/src/server/common/get-server-auth-session.ts
+++ b/src/server/common/get-server-auth-session.ts
@@ -2,6 +2,7 @@ import { type GetServerSidePropsContext } from 'next';
 import jwt from 'jsonwebtoken';
 import { getConfig } from '../core/TipiConfig';
 import TipiCache from '../core/TipiCache';
+import { Logger } from '../core/Logger';
 
 export const getServerAuthSession = async (ctx: { req: GetServerSidePropsContext['req']; res: GetServerSidePropsContext['res'] }) => {
   const { req } = ctx;
@@ -19,7 +20,7 @@ export const getServerAuthSession = async (ctx: { req: GetServerSidePropsContext
         };
       }
     } catch (err) {
-      console.error(err);
+      Logger.info(err);
     }
   }
 


### PR DESCRIPTION
## Purpose
In the `_app.tsx` we were fetching the status of the application with a `refetchInterval` which was re-rendering all the components every X seconds. This is not ideal so I added a flag to disable the query if we are not waiting for a status change.

## Changes
- Create new globally accessible state `setPollStatus` to tell if we should be polling for the status or not
- Start polling when restarting or updating the app
