### PR TITLE
fix(app-store): incorrect breadcrumbs displayed in app store

### DIFF
--- a/src/client/modules/AppStore/helpers/__tests__/table.helpers.test.ts
+++ b/src/client/modules/AppStore/helpers/__tests__/table.helpers.test.ts
@@ -1,0 +1,50 @@
+import { createAppConfig } from '../../../../../server/tests/apps.factory';
+import { limitText, sortTable } from '../table.helpers';
+import { AppTableData } from '../table.types';
+
+describe('sortTable function', () => {
+  const app = createAppConfig({ name: 'a', categories: ['social'] });
+  const app2 = createAppConfig({ name: 'b', categories: ['network', 'automation'] });
+  const app3 = createAppConfig({ name: 'c', categories: ['network'] });
+
+  // Randomize the order of the apps
+  const data: AppTableData = [app3, app, app2];
+
+  it('should sort by name in ascending order', () => {
+    const sortedData = sortTable({ data, direction: 'asc', col: 'name', search: '' });
+
+    expect(sortedData).toEqual([app, app2, app3]);
+  });
+
+  it('should sort by name in descending order', () => {
+    const sortedData = sortTable({ data, direction: 'desc', col: 'name', search: '' });
+
+    expect(sortedData).toEqual([app3, app2, app]);
+  });
+
+  it('should filter by search term', () => {
+    const sortedData = sortTable({ data, direction: 'asc', col: 'name', search: 'b' });
+
+    expect(sortedData).toEqual([app2]);
+  });
+
+  it('should filter by category', () => {
+    const sortedData = sortTable({ data, direction: 'asc', col: 'name', search: '', category: 'automation' });
+
+    expect(sortedData).toEqual([app2]);
+  });
+});
+
+describe('limitText function', () => {
+  it('should limit the text to the given limit', () => {
+    const limitedText = limitText('Lorem ipsum dolor sit amet', 10);
+
+    expect(limitedText).toEqual('Lorem ipsu...');
+  });
+
+  it('should not limit the text if it is shorter than the limit', () => {
+    const limitedText = limitText('Lorem ipsum dolor sit amet', 100);
+
+    expect(limitedText).toEqual('Lorem ipsum dolor sit amet');
+  });
+});

--- a/src/client/modules/AppStore/helpers/table.helpers.ts
+++ b/src/client/modules/AppStore/helpers/table.helpers.ts
@@ -18,10 +18,8 @@ export const sortTable = (params: SortParams) => {
     if (aVal < bVal) {
       return direction === 'asc' ? -1 : 1;
     }
-    if (aVal > bVal) {
-      return direction === 'asc' ? 1 : -1;
-    }
-    return 0;
+
+    return direction === 'asc' ? 1 : -1;
   });
 
   if (category) {

--- a/src/client/modules/Apps/pages/AppDetailsPage/AppDetailsPage.test.tsx
+++ b/src/client/modules/Apps/pages/AppDetailsPage/AppDetailsPage.test.tsx
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import React from 'react';
 import { render, screen, waitFor } from '../../../../../../tests/test-utils';
 import { AppWithInfo } from '../../../../core/types';
@@ -9,28 +10,12 @@ import { AppDetailsPage } from './AppDetailsPage';
 describe('AppDetailsPage', () => {
   it('should render', async () => {
     // Arrange
-    render(<AppDetailsPage appId="nothing" />);
+    render(<AppDetailsPage appId="nothing" refTitle="" refSlug="" />);
 
     // Assert
     await waitFor(() => {
       expect(screen.getByTestId('app-details')).toBeInTheDocument();
     });
-  });
-
-  it('should correctly pass the appId to the AppDetailsContainer', async () => {
-    // Arrange
-    const props = AppDetailsPage.getInitialProps?.({ query: { id: 'random' } } as any);
-
-    // Assert
-    expect(props).toHaveProperty('appId', 'random');
-  });
-
-  it('should transform the appId to a string', async () => {
-    // Arrange
-    const props = AppDetailsPage.getInitialProps?.({ query: { id: [123] } } as any);
-
-    // Assert
-    expect(props).toHaveProperty('appId', '123');
   });
 
   it('should set the breadcrumb prop of the Layout component to an array containing two elements with the correct name and href properties', async () => {
@@ -42,7 +27,11 @@ describe('AppDetailsPage', () => {
         response: app,
       }),
     );
-    render(<AppDetailsPage appId={app.id} />);
+
+    const testSlug = faker.lorem.slug();
+    const testTitle = faker.lorem.sentence();
+
+    render(<AppDetailsPage appId={app.id} refSlug={testSlug} refTitle={testTitle} />);
     await waitFor(() => {
       expect(screen.getByTestId('app-details')).toBeInTheDocument();
     });
@@ -52,10 +41,10 @@ describe('AppDetailsPage', () => {
     const breadcrumbsLinks = await screen.findAllByTestId('breadcrumb-link');
 
     // Assert
-    expect(breadcrumbs[0]).toHaveTextContent('Apps');
-    expect(breadcrumbsLinks[0]).toHaveAttribute('href', '/apps');
+    expect(breadcrumbs[0]).toHaveTextContent(testTitle);
+    expect(breadcrumbsLinks[0]).toHaveAttribute('href', `/${testSlug}`);
 
     expect(breadcrumbs[1]).toHaveTextContent(app.info.name);
-    expect(breadcrumbsLinks[1]).toHaveAttribute('href', `/apps/${app.id}`);
+    expect(breadcrumbsLinks[1]).toHaveAttribute('href', `/${testSlug}/${app.id}`);
   });
 });

--- a/src/client/modules/Apps/pages/AppDetailsPage/AppDetailsPage.tsx
+++ b/src/client/modules/Apps/pages/AppDetailsPage/AppDetailsPage.tsx
@@ -7,14 +7,16 @@ import { AppDetailsContainer } from '../../containers/AppDetailsContainer/AppDet
 
 interface IProps {
   appId: string;
+  refSlug: string;
+  refTitle: string;
 }
 
-export const AppDetailsPage: NextPage<IProps> = ({ appId }) => {
+export const AppDetailsPage: NextPage<IProps> = ({ appId, refSlug, refTitle }) => {
   const { data, error } = trpc.app.getApp.useQuery({ id: appId });
 
   const breadcrumb = [
-    { name: 'Apps', href: '/apps' },
-    { name: data?.info?.name || '', href: `/apps/${data?.id}`, current: true },
+    { name: refTitle, href: `/${refSlug}` },
+    { name: data?.info?.name || '', href: `/${refSlug}/${data?.id}`, current: true },
   ];
 
   // TODO: add loading state
@@ -24,12 +26,4 @@ export const AppDetailsPage: NextPage<IProps> = ({ appId }) => {
       {error && <ErrorPage error={error.message} />}
     </Layout>
   );
-};
-
-AppDetailsPage.getInitialProps = (ctx) => {
-  const { query } = ctx;
-
-  const appId = String(query.id);
-
-  return { appId };
 };

--- a/src/pages/app-store/[id].tsx
+++ b/src/pages/app-store/[id].tsx
@@ -1,1 +1,13 @@
-export { AppDetailsPage as default } from '../../client/modules/Apps/pages/AppDetailsPage';
+import { AppDetailsPage } from '../../client/modules/Apps/pages/AppDetailsPage';
+
+const Page = AppDetailsPage;
+
+Page.getInitialProps = (ctx) => {
+  const { query } = ctx;
+
+  const appId = String(query.id);
+
+  return { appId, refSlug: 'app-store', refTitle: 'App Store' };
+};
+
+export default Page;

--- a/src/pages/apps/[id].tsx
+++ b/src/pages/apps/[id].tsx
@@ -1,1 +1,13 @@
-export { AppDetailsPage as default } from '../../client/modules/Apps/pages/AppDetailsPage';
+import { AppDetailsPage } from '../../client/modules/Apps/pages/AppDetailsPage';
+
+const Page = AppDetailsPage;
+
+Page.getInitialProps = (ctx) => {
+  const { query } = ctx;
+
+  const appId = String(query.id);
+
+  return { appId, refSlug: 'apps', refTitle: 'Apps' };
+};
+
+export default Page;

--- a/src/server/tests/apps.factory.ts
+++ b/src/server/tests/apps.factory.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { App, PrismaClient } from '@prisma/client';
 import { Architecture } from '../core/TipiConfig/TipiConfig';
 import { AppInfo, appInfoSchema } from '../services/apps/apps.helpers';
-import { APP_CATEGORIES } from '../services/apps/apps.types';
+import { AppCategory, APP_CATEGORIES } from '../services/apps/apps.types';
 
 interface IProps {
   installed?: boolean;
@@ -17,6 +17,8 @@ interface IProps {
 
 type CreateConfigParams = {
   id?: string;
+  name?: string;
+  categories?: AppCategory[];
 };
 
 const createAppConfig = (props?: CreateConfigParams) =>
@@ -24,13 +26,13 @@ const createAppConfig = (props?: CreateConfigParams) =>
     id: props?.id || faker.random.alphaNumeric(32),
     available: true,
     port: faker.datatype.number({ min: 30, max: 65535 }),
-    name: faker.random.alphaNumeric(32),
+    name: props?.name || faker.random.alphaNumeric(32),
     description: faker.random.alphaNumeric(32),
     tipi_version: 1,
     short_desc: faker.random.alphaNumeric(32),
     author: faker.random.alphaNumeric(32),
     source: faker.internet.url(),
-    categories: [APP_CATEGORIES.AUTOMATION],
+    categories: props?.categories || [APP_CATEGORIES.AUTOMATION],
   });
 
 const createApp = async (props: IProps, db?: PrismaClient) => {


### PR DESCRIPTION
## Purpose
This PR fixes a bug where the breadcrumbs were displayed wrongly in the app-store. Whenever you came from the app store or from the my apps page, it would always be `/apps/...`

## Changes
- Added props `refSlug` and `refTitle` in `AppDetailsPage` component
- Pass these props accordingly in bot app-store and apps