### PR TITLE
fix(app.sh): force recreate containers on start

### DIFF
--- a/scripts/app.sh
+++ b/scripts/app.sh
@@ -181,7 +181,7 @@ function start_app() {
     write_log "Failed to pull app ${app}"
   fi
 
-  if ! compose "${app}" up --detach; then
+  if ! compose "${app}" up --detach --force-recreate --remove-orphans; then
     write_log "Failed to start app ${app}"
     exit 1
   fi
@@ -217,15 +217,14 @@ function uninstall_app() {
 function update_app() {
   local app="${1}"
 
-  if ! compose "${app}" up --detach; then
+  if ! compose "${app}" up --detach --force-recreate --remove-orphans; then
     write_log "Failed to update app ${app}"
-    exit 1
   fi
 
   if ! compose "${app}" down --rmi all --remove-orphans; then
     # just stop it if we can't remove the images
     if ! compose "${app}" rm --force --stop; then
-      write_log "Failed to uninstall app ${app}"
+      write_log "Failed to update app ${app}"
       exit 1
     fi
   fi


### PR DESCRIPTION
## Purpose
This Pull Request addresses #334
If some apps are not stopped correctly (or manually) before starting Tipi again, users will receive an error about the network.

## Changes
- Added the `--force-recreate` option in both update and start in order to force the container to re-create instead of trying to start in its previous state