### PR TITLE
 feat: display update release notes

### DIFF
--- a/src/client/mocks/handlers.ts
+++ b/src/client/mocks/handlers.ts
@@ -7,7 +7,7 @@ export const handlers = [
   getTRPCMock({
     path: ['system', 'getVersion'],
     type: 'query',
-    response: { current: '1.0.0', latest: '1.0.0' },
+    response: { current: '1.0.0', latest: '1.0.0', body: 'hello' },
   }),
   getTRPCMock({
     path: ['system', 'update'],

--- a/src/client/modules/Settings/containers/GeneralActions/GeneralActions.test.tsx
+++ b/src/client/modules/Settings/containers/GeneralActions/GeneralActions.test.tsx
@@ -13,7 +13,7 @@ describe('Test: GeneralActions', () => {
 
   it('should show toast if update mutation fails', async () => {
     // arrange
-    server.use(getTRPCMock({ path: ['system', 'getVersion'], response: { current: '1.0.0', latest: '2.0.0' } }));
+    server.use(getTRPCMock({ path: ['system', 'getVersion'], response: { current: '1.0.0', latest: '2.0.0', body: '' } }));
     server.use(getTRPCMockError({ path: ['system', 'update'], type: 'mutation', status: 500, message: 'Something went wrong' }));
     render(<GeneralActions />);
     await waitFor(() => {
@@ -35,7 +35,7 @@ describe('Test: GeneralActions', () => {
   it('should log user out if update is successful', async () => {
     // arrange
     localStorage.setItem('token', '123');
-    server.use(getTRPCMock({ path: ['system', 'getVersion'], response: { current: '1.0.0', latest: '2.0.0' } }));
+    server.use(getTRPCMock({ path: ['system', 'getVersion'], response: { current: '1.0.0', latest: '2.0.0', body: '' } }));
     server.use(getTRPCMock({ path: ['system', 'update'], response: true }));
     render(<GeneralActions />);
     await waitFor(() => {

--- a/src/client/modules/Settings/containers/GeneralActions/GeneralActions.tsx
+++ b/src/client/modules/Settings/containers/GeneralActions/GeneralActions.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import semver from 'semver';
 import { toast } from 'react-hot-toast';
+import Markdown from '@/components/Markdown/Markdown';
+import { IconStar } from '@tabler/icons-react';
 import { Button } from '../../../../components/ui/Button';
 import { useDisclosure } from '../../../../hooks/useDisclosure';
 import { RestartModal } from '../../components/RestartModal';
@@ -60,18 +62,31 @@ export const GeneralActions = () => {
 
     return (
       <div>
-        <Button onClick={updateDisclosure.open} className="mr-2 btn-success">
+        {versionQuery.data?.body && (
+          <div className="mt-3 card col-4">
+            <div className="card-stamp">
+              <div className="card-stamp-icon bg-yellow">
+                <IconStar size={80} />
+              </div>
+            </div>
+            <div className="card-body">
+              <Markdown className="">{versionQuery.data.body}</Markdown>
+            </div>
+          </div>
+        )}
+        <Button onClick={updateDisclosure.open} className="mt-3 mr-2 btn-success">
           Update to {versionQuery.data?.latest}
         </Button>
       </div>
     );
   };
+
   return (
     <>
       <div className="card-body">
         <h2 className="mb-4">Actions</h2>
-        <h3 className="card-title mt-4">Version {versionQuery.data?.current}</h3>
-        <p className="card-subtitle">Stay up to date with the latest version of Tipi</p>
+        <h3 className="card-title mt-4">Current version: {versionQuery.data?.current}</h3>
+        <p className="card-subtitle">{isLatest ? 'Stay up to date with the latest version of Tipi' : `A new version (${versionQuery.data?.latest}) of Tipi is available`}</p>
         {renderUpdate()}
         <h3 className="card-title mt-4">Maintenance</h3>
         <p className="card-subtitle">Common actions to perform on your instance</p>

--- a/src/server/services/system/system.service.test.ts
+++ b/src/server/services/system/system.service.test.ts
@@ -66,10 +66,11 @@ describe('Test: getVersion', () => {
     jest.restoreAllMocks();
   });
 
-  it('It should return version', async () => {
+  it('It should return version with body', async () => {
     // Arrange
+    const body = faker.random.words(10);
     // @ts-expect-error Mocking fetch
-    fetch.mockImplementationOnce(() => Promise.resolve({ json: () => Promise.resolve({ name: `v${faker.random.numeric(1)}.${faker.random.numeric(1)}.${faker.random.numeric()}` }) }));
+    fetch.mockImplementationOnce(() => Promise.resolve({ json: () => Promise.resolve({ name: `v${faker.random.numeric(1)}.${faker.random.numeric(1)}.${faker.random.numeric()}`, body }) }));
 
     // Act
     const version = await SystemService.getVersion();
@@ -78,6 +79,7 @@ describe('Test: getVersion', () => {
     expect(version).toBeDefined();
     expect(version.current).toBeDefined();
     expect(semver.valid(version.latest)).toBeTruthy();
+    expect(version.body).toBeDefined();
   });
 
   it('Should return undefined for latest if request fails', async () => {

--- a/src/server/services/system/system.service.ts
+++ b/src/server/services/system/system.service.ts
@@ -41,19 +41,23 @@ export class SystemServiceClass {
    *
    * @returns {Promise<{ current: string; latest: string }>} The current and latest version
    */
-  public getVersion = async (): Promise<{ current: string; latest?: string }> => {
+  public getVersion = async () => {
     try {
       let version = await this.cache.get('latestVersion');
+      let body = await this.cache.get('latestVersionBody');
 
       if (!version) {
         const data = await fetch('https://api.github.com/repos/meienberger/runtipi/releases/latest');
-        const release = (await data.json()) as { name: string };
+        const release = (await data.json()) as { name: string; body: string };
 
         version = release.name.replace('v', '');
+        body = release.body;
+
         await this.cache.set('latestVersion', version?.replace('v', '') || '', 60 * 60);
+        await this.cache.set('latestVersionBody', body || '', 60 * 60);
       }
 
-      return { current: TipiConfig.getConfig().version, latest: version?.replace('v', '') };
+      return { current: TipiConfig.getConfig().version, latest: version?.replace('v', ''), body };
     } catch (e) {
       Logger.error(e);
       return { current: TipiConfig.getConfig().version, latest: undefined };


### PR DESCRIPTION
## Purpose
This PR adds the ability to view the GitHub release notes on the dashboard before updating.

![Screenshot 2023-04-10 at 11 47 06](https://user-images.githubusercontent.com/47644445/230877880-d3153f98-4a14-43af-a191-502904ac8a5e.png)
