### PR TITLE
feat: redis healthcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
 
 env:
   ROOT_FOLDER: /runtipi
-  JWT_SECRET: "secret"
+  JWT_SECRET: 'secret'
   ROOT_FOLDER_HOST: /tipi
   APPS_REPO_ID: repo-id
   INTERNAL_IP: localhost
@@ -67,8 +67,12 @@ jobs:
       - name: Run linter
         run: pnpm lint
 
+      - name: Get number of CPU cores
+        id: cpu-cores
+        uses: SimenB/github-actions-cpu-cores@v1
+
       - name: Run tests
-        run: pnpm test
+        run: pnpm run test --max-workers ${{ steps.cpu-cores.outputs.count }}
 
       - uses: codecov/codecov-action@v3
         with:

--- a/__mocks__/redis.ts
+++ b/__mocks__/redis.ts
@@ -12,6 +12,7 @@ export const createClient = jest.fn(() => {
     quit: jest.fn(),
     del: (key: string) => values.delete(key),
     ttl: (key: string) => expirations.get(key),
+    on: jest.fn(),
     keys: (key: string) => {
       const keys = [];
       // eslint-disable-next-line no-restricted-syntax

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,6 +30,11 @@ services:
       - 6379:6379
     volumes:
       - ./data/redis:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 10s
+      retries: 120
     networks:
       - tipi_main_network
 
@@ -40,6 +45,8 @@ services:
     container_name: dashboard
     depends_on:
       tipi-db:
+        condition: service_healthy
+      tipi-redis:
         condition: service_healthy
     environment:
       NODE_ENV: development

--- a/docker-compose.rc.yml
+++ b/docker-compose.rc.yml
@@ -42,6 +42,11 @@ services:
     restart: unless-stopped
     volumes:
       - ./data/redis:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 10s
+      retries: 120
     networks:
       - tipi_main_network
 
@@ -52,6 +57,8 @@ services:
       - tipi_main_network
     depends_on:
       tipi-db:
+        condition: service_healthy
+      tipi-redis:
         condition: service_healthy
     environment:
       NODE_ENV: production

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -41,6 +41,11 @@ services:
     restart: unless-stopped
     volumes:
       - ./data/redis:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 10s
+      retries: 120
     networks:
       - tipi_main_network
 
@@ -54,6 +59,8 @@ services:
       - tipi_main_network
     depends_on:
       tipi-db:
+        condition: service_healthy
+      tipi-redis:
         condition: service_healthy
     environment:
       NODE_ENV: production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,11 @@ services:
     restart: unless-stopped
     volumes:
       - ./data/redis:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 10s
+      retries: 120
     networks:
       - tipi_main_network
 
@@ -52,6 +57,8 @@ services:
       - tipi_main_network
     depends_on:
       tipi-db:
+        condition: service_healthy
+      tipi-redis:
         condition: service_healthy
     environment:
       NODE_ENV: production

--- a/src/server/core/TipiCache/TipiCache.ts
+++ b/src/server/core/TipiCache/TipiCache.ts
@@ -1,4 +1,5 @@
 import { createClient, RedisClientType } from 'redis';
+import { Logger } from '../Logger';
 import { getConfig } from '../TipiConfig';
 
 const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
@@ -11,6 +12,10 @@ class TipiCache {
   constructor() {
     const client = createClient({
       url: `redis://${getConfig().REDIS_HOST}:6379`,
+    });
+
+    client.on('error', (err) => {
+      Logger.error(`Redis error: ${err}`);
     });
 
     this.client = client as RedisClientType;


### PR DESCRIPTION
## Purpose
Sometimes, the Redis instance is not yet ready and the client is starting anyways causing issues in the dashboard. This PR adds a `healthcheck` in the docker-compose file in order to start the dashboard only when Redis is healthy

## Changes
- Added a `healthcheck` for Redis in all `docker-compose.yml`
- Added error logs for Redis