### PR TITLE
feat: add app website info in details tab

### DIFF
--- a/src/client/modules/Apps/components/AppDetailsTabs.tsx
+++ b/src/client/modules/Apps/components/AppDetailsTabs.tsx
@@ -47,6 +47,14 @@ export const AppDetailsTabs: React.FC<IProps> = ({ info }) => (
             ))}
           </DataGridItem>
         )}
+        {info.website && (
+          <DataGridItem title="Website">
+            <a target="_blank" rel="noreferrer" className="text-blue-500 text-xs" href={info.website}>
+              {info.website}
+              <IconExternalLink size={15} className="ms-1 mb-1" />
+            </a>
+          </DataGridItem>
+        )}
       </DataGrid>
     </TabsContent>
   </Tabs>


### PR DESCRIPTION
## Purpose
Add a new section to display the app website in the "Base info" tab

![Screenshot 2023-04-15 at 14 33 34](https://user-images.githubusercontent.com/47644445/232223894-c6ac2456-ed10-4af4-a224-bb15b2102942.png)
