### PR TITLE
fix: return default values of 0 when system-info.json fails to parse

### DIFF
--- a/src/server/services/system/system.service.test.ts
+++ b/src/server/services/system/system.service.test.ts
@@ -19,17 +19,22 @@ beforeEach(async () => {
 });
 
 describe('Test: systemInfo', () => {
-  it('Should throw if system-info.json does not exist', () => {
-    try {
-      SystemServiceClass.systemInfo();
-    } catch (e: unknown) {
-      if (e instanceof Error) {
-        expect(e).toBeDefined();
-        expect(e.message).toBe('Error parsing system info');
-      } else {
-        expect(true).toBe(false);
-      }
-    }
+  it('should return default values when system-info.json is not present', () => {
+    // arrange
+    const systemInfo = SystemServiceClass.systemInfo();
+
+    // assert
+    expect(systemInfo).toBeDefined();
+    expect(systemInfo.cpu).toBeDefined();
+    expect(systemInfo.memory).toBeDefined();
+    expect(systemInfo.disk).toBeDefined();
+    expect(systemInfo.cpu.load).toBe(0);
+    expect(systemInfo.memory.total).toBe(0);
+    expect(systemInfo.memory.used).toBe(0);
+    expect(systemInfo.memory.available).toBe(0);
+    expect(systemInfo.disk.total).toBe(0);
+    expect(systemInfo.disk.used).toBe(0);
+    expect(systemInfo.disk.available).toBe(0);
   });
 
   it('It should return system info', async () => {

--- a/src/server/services/system/system.service.ts
+++ b/src/server/services/system/system.service.ts
@@ -68,10 +68,12 @@ export class SystemServiceClass {
     const info = systemInfoSchema.safeParse(readJsonFile('/runtipi/state/system-info.json'));
 
     if (!info.success) {
-      throw new Error('Error parsing system info');
-    } else {
-      return info.data;
+      Logger.error('Error parsing system info', info.error);
+
+      return { cpu: { load: 0 }, disk: { total: 0, used: 0, available: 0 }, memory: { total: 0, available: 0, used: 0 } };
     }
+
+    return info.data;
   };
 
   public update = async (): Promise<boolean> => {


### PR DESCRIPTION
## Purpose
On some operating systems, or under special conditions, the script `system-info.sh` fails to create the json. This causes the UI to show an error that can be avoided using default values. The user would still understand there is an issue with the script but the UX will be better by not showing an error as the opening page of the dashboard.