### PR TITLE
Enable Traefik Dynamic Configs via File

### DIFF
--- a/traefik/dynamic/dynamic.yml
+++ b/traefik/dynamic/dynamic.yml
@@ -1,0 +1,4 @@
+http:
+  serversTransports:
+    insecuretransport:
+      insecureSkipVerify: true

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -7,6 +7,9 @@ providers:
     endpoint: "unix:///var/run/docker.sock"
     watch: true
     exposedByDefault: false
+  file:
+    directory: /root/.config/dynamic
+    watch: true
 
 entryPoints:
   web:


### PR DESCRIPTION
Gives Traefik the possibility to have a dynamic config. Worked with mastodon but did not interfere with any other apps