### PR TITLE
fix(apps.helpers): make required boolean field pass with false value

### DIFF
--- a/src/server/services/apps/apps.helpers.test.ts
+++ b/src/server/services/apps/apps.helpers.test.ts
@@ -183,7 +183,7 @@ describe('Test: generateEnvFile()', () => {
     const app = await insertApp({}, appConfig, db);
 
     // act & assert
-    expect(() => generateEnvFile(Object.assign(app, { config: { TEST_FIELD: undefined } }))).toThrowError('Variable TEST_FIELD is required');
+    expect(() => generateEnvFile(Object.assign(app, { config: { TEST_FIELD: undefined } }))).toThrowError('Variable test is required');
   });
 
   it('Should throw an error if app does not exist', async () => {

--- a/src/server/services/apps/apps.helpers.ts
+++ b/src/server/services/apps/apps.helpers.ts
@@ -197,8 +197,8 @@ export const generateEnvFile = (app: App) => {
     const formValue = castAppConfig(app.config)[field.env_variable];
     const envVar = field.env_variable;
 
-    if (formValue) {
-      envFile += `${envVar}=${formValue}\n`;
+    if (formValue || typeof formValue === 'boolean') {
+      envFile += `${envVar}=${String(formValue)}\n`;
     } else if (field.type === 'random') {
       if (envMap.has(envVar)) {
         envFile += `${envVar}=${envMap.get(envVar)}\n`;
@@ -209,7 +209,7 @@ export const generateEnvFile = (app: App) => {
         envFile += `${envVar}=${randomString}\n`;
       }
     } else if (field.required) {
-      throw new Error(`Variable ${field.env_variable} is required`);
+      throw new Error(`Variable ${field.label || field.env_variable} is required`);
     }
   });
 


### PR DESCRIPTION
## Purpose
It is currently impossible to install an app with a boolean value set to `false` if that field is required. This PR solves the issue by checking for the field type before throwing an error