### PR TITLE
feat: allow variable replacement in data files

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,7 @@ name: E2E Tests
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened]
     branches:
       - release/*
 

--- a/__mocks__/fs-extra.ts
+++ b/__mocks__/fs-extra.ts
@@ -57,7 +57,9 @@ class FsMock {
   };
 
   mkdirSync = (p: string) => {
-    this.mockFiles[p] = Object.create(null);
+    if (!this.mockFiles[p]) {
+      this.mockFiles[p] = [];
+    }
   };
 
   rmSync = (p: string) => {
@@ -128,6 +130,18 @@ class FsMock {
     },
     writeFile: async (p: string, data: string | string[]) => {
       this.mockFiles[p] = data;
+
+      const dir = path.dirname(p);
+      if (!this.mockFiles[dir]) {
+        this.mockFiles[dir] = [];
+      }
+
+      this.mockFiles[dir].push(path.basename(p));
+    },
+    mkdir: async (p: string) => {
+      if (!this.mockFiles[p]) {
+        this.mockFiles[p] = [];
+      }
     },
     readdir: async (p: string) => {
       const files: string[] = [];
@@ -145,6 +159,19 @@ class FsMock {
       });
 
       return files;
+    },
+    lstat: async (p: string) => {
+      return {
+        isDirectory: () => {
+          return this.mockFiles[p] instanceof Array;
+        },
+      };
+    },
+    readFile: async (p: string) => {
+      return this.mockFiles[p];
+    },
+    copyFile: async (source: string, destination: string) => {
+      this.mockFiles[destination] = this.mockFiles[source];
     },
   };
 }

--- a/__mocks__/fs-extra.ts
+++ b/__mocks__/fs-extra.ts
@@ -129,6 +129,23 @@ class FsMock {
     writeFile: async (p: string, data: string | string[]) => {
       this.mockFiles[p] = data;
     },
+    readdir: async (p: string) => {
+      const files: string[] = [];
+
+      const depth = p.split('/').length;
+
+      Object.keys(this.mockFiles).forEach((file) => {
+        if (file.startsWith(p)) {
+          const fileDepth = file.split('/').length;
+
+          if (fileDepth === depth + 1) {
+            files.push(file.split('/').pop() || '');
+          }
+        }
+      });
+
+      return files;
+    },
   };
 }
 

--- a/scripts/app.sh
+++ b/scripts/app.sh
@@ -146,11 +146,6 @@ function install_app() {
     exit 1
   fi
 
-  # Copy default data dir to app data dir if it exists
-  if [[ -d "${app_dir}/data" ]]; then
-    cp -r "${app_dir}/data" "${app_data_dir}/data"
-  fi
-
   ensure_permissions "${app}"
 
   if ! compose "${app}" up -d; then

--- a/src/server/services/apps/apps.helpers.ts
+++ b/src/server/services/apps/apps.helpers.ts
@@ -269,6 +269,7 @@ export const copyDataDir = async (id: string) => {
   };
 
   const processDir = async (path: string) => {
+    await fs.promises.mkdir(`/app/storage/app-data/${id}/data/${path}`, { recursive: true });
     const files = await fs.promises.readdir(`/runtipi/apps/${id}/data/${path}`);
 
     await Promise.all(

--- a/src/server/services/apps/apps.service.ts
+++ b/src/server/services/apps/apps.service.ts
@@ -3,7 +3,7 @@ import { App } from '@/server/db/schema';
 import { AppQueries } from '@/server/queries/apps/apps.queries';
 import { TranslatedError } from '@/server/utils/errors';
 import { Database } from '@/server/db';
-import { checkAppRequirements, checkEnvFile, generateEnvFile, getAvailableApps, ensureAppFolder, AppInfo, getAppInfo, getUpdateInfo } from './apps.helpers';
+import { checkAppRequirements, checkEnvFile, generateEnvFile, getAvailableApps, ensureAppFolder, AppInfo, getAppInfo, getUpdateInfo, copyDataDir } from './apps.helpers';
 import { getConfig } from '../../core/TipiConfig';
 import { EventDispatcher } from '../../core/EventDispatcher';
 import { Logger } from '../../core/Logger';
@@ -125,7 +125,7 @@ export class AppServiceClass {
       checkAppRequirements(id);
 
       // Create app folder
-      createFolder(`/app/storage/app-data/${id}`);
+      createFolder(`/app/storage/app-data/${id}/data`);
 
       const appInfo = getAppInfo(id);
 
@@ -154,6 +154,7 @@ export class AppServiceClass {
       if (newApp) {
         // Create env file
         generateEnvFile(newApp);
+        await copyDataDir(id);
       }
 
       // Run script


### PR DESCRIPTION
## Purpose
As a developer, I need to be able to use my app environment variables in any data file and not only `docker-compose.yml`

## Changes
- Copy data folder from node instead of the bash script
- Recursively look for files with the extension `.template` and replace `{{VALUES}}` with available environment variables