### PR TITLE
feat: allow local domain with self-signed cert

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ ROOT_FOLDER_HOST=/Users/nicolas/Projects/runtipi
 NGINX_PORT=3000
 NGINX_PORT_SSL=443
 POSTGRES_PASSWORD=postgres
-DOMAIN=tipi.localhost
+DOMAIN=example.com
 STORAGE_PATH=/Users/nicolas/Projects/runtipi
 REDIS_HOST=tipi-redis
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
   REDIS_HOST: redis
   APPS_REPO_URL: https://repo.github.com/
   DOMAIN: localhost
+  LOCAL_DOMAIN: tipi.lan
   TIPI_VERSION: 0.0.1
 
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,7 +104,7 @@ jobs:
             cd runtipi
             echo 'Checking out branch ${{ github.head_ref }}'
             git checkout ${{ github.head_ref }}
-            sudo ./scripts/start-e2e.sh latest
+            sudo ./scripts/start-e2e.sh e2e
             echo 'App deployed'
           host: ${{ steps.get-droplet-ip.outputs.droplet_ip }}
           user: root

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ node_modules/
 /repos/
 /apps/
 traefik/shared
+traefik/tls
 
 # media folder
 media

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -80,6 +80,7 @@ services:
       ARCHITECTURE: ${ARCHITECTURE}
       REDIS_HOST: ${REDIS_HOST}
       DEMO_MODE: ${DEMO_MODE}
+      LOCAL_DOMAIN: ${LOCAL_DOMAIN}
     networks:
       - tipi_main_network
     ports:
@@ -93,6 +94,7 @@ services:
       - ${PWD}/repos:/runtipi/repos:ro
       - ${PWD}/apps:/runtipi/apps
       - ${PWD}/logs:/app/logs
+      - ${PWD}/traefik:/runtipi/traefik
       - ${STORAGE_PATH}:/app/storage
     labels:
       traefik.enable: true

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,22 @@
 version: '3.7'
 
 services:
+  reverse-proxy:
+    container_name: reverse-proxy
+    image: traefik:v2.8
+    restart: on-failure
+    ports:
+      - 80:80
+      - 443:443
+      - 8080:8080
+    command: --providers.docker
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ${PWD}/traefik:/root/.config
+      - ${PWD}/traefik/shared:/shared
+    networks:
+      - tipi_main_network
+
   tipi-db:
     container_name: tipi-db
     image: postgres:14
@@ -78,6 +94,21 @@ services:
       - ${PWD}/apps:/runtipi/apps
       - ${PWD}/logs:/app/logs
       - ${STORAGE_PATH}:/app/storage
+    labels:
+      traefik.enable: true
+      # Local domain
+      traefik.http.routers.dashboard-local-insecure.rule: Host(`${LOCAL_DOMAIN}`)
+      traefik.http.routers.dashboard-local-insecure.entrypoints: web
+      traefik.http.routers.dashboard-local-insecure.service: dashboard-local-insecure
+      traefik.http.middlewares.redirect-to-https.redirectscheme.scheme: https
+      traefik.http.services.dashboard-local-insecure.loadbalancer.server.port: 3000
+      traefik.http.routers.dashboard-local-insecure.middlewares: redirect-to-https
+      # secure
+      traefik.http.routers.dashboard-local.rule: Host(`${LOCAL_DOMAIN}`)
+      traefik.http.routers.dashboard-local.entrypoints: websecure
+      traefik.http.routers.dashboard-local.tls: true
+      traefik.http.routers.dashboard-local.service: dashboard-local
+      traefik.http.services.dashboard-local.loadbalancer.server.port: 3000
 
 networks:
   tipi_main_network:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -96,19 +96,18 @@ services:
       - ${STORAGE_PATH}:/app/storage
     labels:
       traefik.enable: true
+      traefik.http.services.dashboard.loadbalancer.server.port: 3000
+      traefik.http.middlewares.redirect-to-https.redirectscheme.scheme: https
       # Local domain
       traefik.http.routers.dashboard-local-insecure.rule: Host(`${LOCAL_DOMAIN}`)
       traefik.http.routers.dashboard-local-insecure.entrypoints: web
-      traefik.http.routers.dashboard-local-insecure.service: dashboard-local-insecure
-      traefik.http.middlewares.redirect-to-https.redirectscheme.scheme: https
-      traefik.http.services.dashboard-local-insecure.loadbalancer.server.port: 3000
+      traefik.http.routers.dashboard-local-insecure.service: dashboard
       traefik.http.routers.dashboard-local-insecure.middlewares: redirect-to-https
       # secure
       traefik.http.routers.dashboard-local.rule: Host(`${LOCAL_DOMAIN}`)
       traefik.http.routers.dashboard-local.entrypoints: websecure
       traefik.http.routers.dashboard-local.tls: true
-      traefik.http.routers.dashboard-local.service: dashboard-local
-      traefik.http.services.dashboard-local.loadbalancer.server.port: 3000
+      traefik.http.routers.dashboard-local.service: dashboard
 
 networks:
   tipi_main_network:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -89,6 +89,19 @@ services:
       traefik.http.routers.dashboard.service: dashboard
       traefik.http.routers.dashboard.entrypoints: web
       traefik.http.services.dashboard.loadbalancer.server.port: 3000
+      # Local domain
+      traefik.http.routers.dashboard-local-insecure.rule: Host(`${LOCAL_DOMAIN}`)
+      traefik.http.routers.dashboard-local-insecure.entrypoints: web
+      traefik.http.routers.dashboard-local-insecure.service: dashboard-local-insecure
+      traefik.http.middlewares.redirect-to-https.redirectscheme.scheme: https
+      traefik.http.services.dashboard-local-insecure.loadbalancer.server.port: 3000
+      traefik.http.routers.dashboard-local-insecure.middlewares: redirect-to-https
+      traefik.http.routers.dashboard-local.rule: Host(`${LOCAL_DOMAIN}`)
+      traefik.http.routers.dashboard-local.entrypoints: websecure
+      traefik.http.routers.dashboard-local.redirectregex.regex: ^https://(.*)$
+      traefik.http.routers.dashboard-local.tls: true
+      traefik.http.routers.dashboard-local.service: dashboard-local
+      traefik.http.services.dashboard-local.loadbalancer.server.port: 3000
 
 networks:
   tipi_main_network:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -76,11 +76,13 @@ services:
       ARCHITECTURE: ${ARCHITECTURE}
       REDIS_HOST: ${REDIS_HOST}
       DEMO_MODE: ${DEMO_MODE}
+      LOCAL_DOMAIN: ${LOCAL_DOMAIN}
     volumes:
       - ${PWD}/state:/runtipi/state
       - ${PWD}/repos:/runtipi/repos:ro
       - ${PWD}/apps:/runtipi/apps
       - ${PWD}/logs:/app/logs
+      - ${PWD}/traefik:/runtipi/traefik
       - ${PWD}:/app/storage
     labels:
       # Main

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -83,25 +83,32 @@ services:
       - ${PWD}/logs:/app/logs
       - ${PWD}:/app/storage
     labels:
+      # Main
       traefik.enable: true
-      # Web
+      traefik.http.middlewares.redirect-to-https.redirectscheme.scheme: https
+      traefik.http.services.dashboard.loadbalancer.server.port: 3000
+      # Local ip
       traefik.http.routers.dashboard.rule: PathPrefix("/")
       traefik.http.routers.dashboard.service: dashboard
       traefik.http.routers.dashboard.entrypoints: web
-      traefik.http.services.dashboard.loadbalancer.server.port: 3000
+      # Websecure
+      traefik.http.routers.dashboard-insecure.rule: Host(`${DOMAIN}`) && PathPrefix(`/`)
+      traefik.http.routers.dashboard-insecure.service: dashboard
+      traefik.http.routers.dashboard-insecure.entrypoints: web
+      traefik.http.routers.dashboard-insecure.middlewares: redirect-to-https
+      traefik.http.routers.dashboard-secure.rule: Host(`${DOMAIN}`) && PathPrefix(`/`)
+      traefik.http.routers.dashboard-secure.service: dashboard
+      traefik.http.routers.dashboard-secure.entrypoints: websecure
+      traefik.http.routers.dashboard-secure.tls.certresolver: myresolver
       # Local domain
       traefik.http.routers.dashboard-local-insecure.rule: Host(`${LOCAL_DOMAIN}`)
       traefik.http.routers.dashboard-local-insecure.entrypoints: web
-      traefik.http.routers.dashboard-local-insecure.service: dashboard-local-insecure
-      traefik.http.middlewares.redirect-to-https.redirectscheme.scheme: https
-      traefik.http.services.dashboard-local-insecure.loadbalancer.server.port: 3000
+      traefik.http.routers.dashboard-local-insecure.service: dashboard
       traefik.http.routers.dashboard-local-insecure.middlewares: redirect-to-https
       traefik.http.routers.dashboard-local.rule: Host(`${LOCAL_DOMAIN}`)
       traefik.http.routers.dashboard-local.entrypoints: websecure
-      traefik.http.routers.dashboard-local.redirectregex.regex: ^https://(.*)$
       traefik.http.routers.dashboard-local.tls: true
-      traefik.http.routers.dashboard-local.service: dashboard-local
-      traefik.http.services.dashboard-local.loadbalancer.server.port: 3000
+      traefik.http.routers.dashboard-local.service: dashboard
 
 networks:
   tipi_main_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,12 +76,14 @@ services:
       ARCHITECTURE: ${ARCHITECTURE}
       REDIS_HOST: ${REDIS_HOST}
       DEMO_MODE: ${DEMO_MODE}
+      LOCAL_DOMAIN: ${LOCAL_DOMAIN}
     volumes:
       - ${PWD}/.env:/runtipi/.env
       - ${PWD}/state:/runtipi/state
       - ${PWD}/repos:/runtipi/repos:ro
       - ${PWD}/apps:/runtipi/apps
       - ${PWD}/logs:/app/logs
+      - ${PWD}/traefik:/runtipi/traefik
       - ${STORAGE_PATH}:/app/storage
     labels:
       # Main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,30 +84,32 @@ services:
       - ${PWD}/logs:/app/logs
       - ${STORAGE_PATH}:/app/storage
     labels:
+      # Main
       traefik.enable: true
-      # Web
+      traefik.http.middlewares.redirect-to-https.redirectscheme.scheme: https
+      traefik.http.services.dashboard.loadbalancer.server.port: 3000
+      # Local ip
       traefik.http.routers.dashboard.rule: PathPrefix("/")
       traefik.http.routers.dashboard.service: dashboard
       traefik.http.routers.dashboard.entrypoints: web
-      traefik.http.services.dashboard.loadbalancer.server.port: 3000
       # Websecure
+      traefik.http.routers.dashboard-insecure.rule: Host(`${DOMAIN}`) && PathPrefix(`/`)
+      traefik.http.routers.dashboard-insecure.service: dashboard
+      traefik.http.routers.dashboard-insecure.entrypoints: web
+      traefik.http.routers.dashboard-insecure.middlewares: redirect-to-https
       traefik.http.routers.dashboard-secure.rule: Host(`${DOMAIN}`) && PathPrefix(`/`)
-      traefik.http.routers.dashboard-secure.service: dashboard-secure
+      traefik.http.routers.dashboard-secure.service: dashboard
       traefik.http.routers.dashboard-secure.entrypoints: websecure
       traefik.http.routers.dashboard-secure.tls.certresolver: myresolver
-      traefik.http.services.dashboard-secure.loadbalancer.server.port: 3000
       # Local domain
       traefik.http.routers.dashboard-local-insecure.rule: Host(`${LOCAL_DOMAIN}`)
       traefik.http.routers.dashboard-local-insecure.entrypoints: web
-      traefik.http.routers.dashboard-local-insecure.service: dashboard-local-insecure
-      traefik.http.middlewares.redirect-to-https.redirectscheme.scheme: https
-      traefik.http.services.dashboard-local-insecure.loadbalancer.server.port: 3000
+      traefik.http.routers.dashboard-local-insecure.service: dashboard
       traefik.http.routers.dashboard-local-insecure.middlewares: redirect-to-https
       traefik.http.routers.dashboard-local.rule: Host(`${LOCAL_DOMAIN}`)
       traefik.http.routers.dashboard-local.entrypoints: websecure
       traefik.http.routers.dashboard-local.tls: true
-      traefik.http.routers.dashboard-local.service: dashboard-local
-      traefik.http.services.dashboard-local.loadbalancer.server.port: 3000
+      traefik.http.routers.dashboard-local.service: dashboard
 
 networks:
   tipi_main_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,18 @@ services:
       traefik.http.routers.dashboard-secure.entrypoints: websecure
       traefik.http.routers.dashboard-secure.tls.certresolver: myresolver
       traefik.http.services.dashboard-secure.loadbalancer.server.port: 3000
+      # Local domain
+      traefik.http.routers.dashboard-local-insecure.rule: Host(`${LOCAL_DOMAIN}`)
+      traefik.http.routers.dashboard-local-insecure.entrypoints: web
+      traefik.http.routers.dashboard-local-insecure.service: dashboard-local-insecure
+      traefik.http.middlewares.redirect-to-https.redirectscheme.scheme: https
+      traefik.http.services.dashboard-local-insecure.loadbalancer.server.port: 3000
+      traefik.http.routers.dashboard-local-insecure.middlewares: redirect-to-https
+      traefik.http.routers.dashboard-local.rule: Host(`${LOCAL_DOMAIN}`)
+      traefik.http.routers.dashboard-local.entrypoints: websecure
+      traefik.http.routers.dashboard-local.tls: true
+      traefik.http.routers.dashboard-local.service: dashboard-local
+      traefik.http.services.dashboard-local.loadbalancer.server.port: 3000
 
 networks:
   tipi_main_network:

--- a/e2e/0003-apps.spec.ts
+++ b/e2e/0003-apps.spec.ts
@@ -30,8 +30,8 @@ test('user can install and uninstall app', async ({ page, context }) => {
   await expect(page.getByText('Running')).toBeVisible({ timeout: 60000 });
   await expect(page.getByText('App installed successfully')).toBeVisible();
 
-  await page.getByTestId('app-details').getByRole('button', { name: 'Open' }).click();
-  const [newPage] = await Promise.all([context.waitForEvent('page'), await page.getByRole('menuitem', { name: 'localhost:8000' }).click()]);
+  await page.getByTestId('app-details').getByRole('button', { name: 'Open' }).press('ArrowDown');
+  const [newPage] = await Promise.all([context.waitForEvent('page'), await page.getByRole('menuitem', { name: `${process.env.SERVER_IP}:8000` }).click()]);
 
   await newPage.waitForLoadState();
   await expect(newPage.getByText('Hello World')).toBeVisible();

--- a/e2e/0003-apps.spec.ts
+++ b/e2e/0003-apps.spec.ts
@@ -30,7 +30,8 @@ test('user can install and uninstall app', async ({ page, context }) => {
   await expect(page.getByText('Running')).toBeVisible({ timeout: 60000 });
   await expect(page.getByText('App installed successfully')).toBeVisible();
 
-  const [newPage] = await Promise.all([context.waitForEvent('page'), await page.getByTestId('app-details').getByRole('button', { name: 'Open' }).click()]);
+  await page.getByTestId('app-details').getByRole('button', { name: 'Open' }).click();
+  const [newPage] = await Promise.all([context.waitForEvent('page'), await page.getByRole('menuitem', { name: 'localhost:8000' }).click()]);
 
   await newPage.waitForLoadState();
   await expect(newPage.getByText('Hello World')).toBeVisible();

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@otplib/plugin-crypto": "^12.0.1",
     "@otplib/plugin-thirty-two": "^12.0.1",
     "@radix-ui/react-dialog": "^1.0.3",
+    "@radix-ui/react-dropdown-menu": "^2.0.5",
     "@radix-ui/react-select": "^1.2.1",
     "@radix-ui/react-switch": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.3",
@@ -87,8 +88,8 @@
   "devDependencies": {
     "@babel/core": "^7.21.8",
     "@faker-js/faker": "^8.0.1",
-    "@testing-library/dom": "^9.3.0",
     "@playwright/test": "^1.32.3",
+    "@testing-library/dom": "^9.3.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ dependencies:
   '@radix-ui/react-dialog':
     specifier: ^1.0.3
     version: 1.0.3(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+  '@radix-ui/react-dropdown-menu':
+    specifier: ^2.0.5
+    version: 2.0.5(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-select':
     specifier: ^1.2.1
     version: 1.2.1(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
@@ -1062,6 +1065,10 @@ packages:
     resolution: {integrity: sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg==}
     dev: false
 
+  /@floating-ui/core@1.2.6:
+    resolution: {integrity: sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==}
+    dev: false
+
   /@floating-ui/dom@0.5.4:
     resolution: {integrity: sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==}
     dependencies:
@@ -1072,6 +1079,12 @@ packages:
     resolution: {integrity: sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==}
     dependencies:
       '@floating-ui/core': 1.2.1
+    dev: false
+
+  /@floating-ui/dom@1.2.9:
+    resolution: {integrity: sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==}
+    dependencies:
+      '@floating-ui/core': 1.2.6
     dev: false
 
   /@floating-ui/react-dom@0.7.2(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
@@ -1086,6 +1099,17 @@ packages:
       use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.7)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
+    dev: false
+
+  /@floating-ui/react-dom@2.0.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Ke0oU3SeuABC2C4OFu2mSAwHIP5WUiV98O9YWoHV4Q5aT6E9k06DV0Khi5uYspR8xmmBk08t8ZDcz3TR3ARkEg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/dom': 1.2.9
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@formatjs/ecma402-abstract@1.11.4:
@@ -1640,6 +1664,12 @@ packages:
       '@babel/runtime': 7.20.13
     dev: false
 
+  /@radix-ui/primitive@1.0.1:
+    resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
+    dependencies:
+      '@babel/runtime': 7.20.13
+    dev: false
+
   /@radix-ui/react-arrow@1.0.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-fqYwhhI9IarZ0ll2cUSfKuXHlJK0qE4AfnRrPBbRwEH/4mGQn04/QFGomLi8TXWIdv9WJk//KgGm+aDxVIr1wA==}
     peerDependencies:
@@ -1648,6 +1678,27 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       '@radix-ui/react-primitive': 1.0.2(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-arrow@1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.7
+      '@types/react-dom': 18.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -1667,6 +1718,30 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-collection@1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
+      '@types/react-dom': 18.2.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-compose-refs@1.0.0(react@18.2.0):
     resolution: {integrity: sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==}
     peerDependencies:
@@ -1676,12 +1751,40 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.7)(react@18.2.0):
+    resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@types/react': 18.2.7
+      react: 18.2.0
+    dev: false
+
   /@radix-ui/react-context@1.0.0(react@18.2.0):
     resolution: {integrity: sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.20.13
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-context@1.0.1(@types/react@18.2.7)(react@18.2.0):
+    resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@types/react': 18.2.7
       react: 18.2.0
     dev: false
 
@@ -1721,6 +1824,20 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@radix-ui/react-direction@1.0.1(@types/react@18.2.7)(react@18.2.0):
+    resolution: {integrity: sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@types/react': 18.2.7
+      react: 18.2.0
+    dev: false
+
   /@radix-ui/react-dismissable-layer@1.0.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-nXZOvFjOuHS1ovumntGV7NNoLaEp9JEvTht3MBjP44NSW5hUKj/8OnfN3+8WmB+CEhN44XaGhpHoSsUIEl5P7Q==}
     peerDependencies:
@@ -1737,12 +1854,78 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-dismissable-layer@1.0.4(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-7UpBa/RKMoHJYjie1gkF1DlK8l1fdU/VKDpoS3rCCo8YBJR294GwcEHyxHw72yvphJ7ld0AXEcSLAzY2F/WyCg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
+      '@types/react-dom': 18.2.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-dropdown-menu@2.0.5(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-xdOrZzOTocqqkCkYo8yRPCib5OkTkqN7lqNCdxwPOdE466DOaNl4N8PkUIlsXthQvW5Wwkd+aEmWpfWlBoDPEw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-menu': 2.0.5(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
+      '@types/react-dom': 18.2.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-focus-guards@1.0.0(react@18.2.0):
     resolution: {integrity: sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.20.13
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-focus-guards@1.0.1(@types/react@18.2.7)(react@18.2.0):
+    resolution: {integrity: sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@types/react': 18.2.7
       react: 18.2.0
     dev: false
 
@@ -1760,6 +1943,29 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-focus-scope@1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-upXdPfqI4islj2CslyfUBNlaJCPybbqRHAi1KER7Isel9Q2AtSJ0zRBZv8mWQiFXD2nyAJ4BhC3yXgZ6kMBSrQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
+      '@types/react-dom': 18.2.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-id@1.0.0(react@18.2.0):
     resolution: {integrity: sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==}
     peerDependencies:
@@ -1768,6 +1974,59 @@ packages:
       '@babel/runtime': 7.20.13
       '@radix-ui/react-use-layout-effect': 1.0.0(react@18.2.0)
       react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-id@1.0.1(@types/react@18.2.7)(react@18.2.0):
+    resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-menu@2.0.5(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Gw4f9pwdH+w5w+49k0gLjN0PfRDHvxmAgG16AbyJZ7zhwZ6PBHKtWohvnSwfusfnK3L68dpBREHpVkj8wEM7ZA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-popper': 1.1.2(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
+      '@types/react-dom': 18.2.4
+      aria-hidden: 1.2.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.2.7)(react@18.2.0)
     dev: false
 
   /@radix-ui/react-popper@1.1.1(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
@@ -1793,6 +2052,36 @@ packages:
       - '@types/react'
     dev: false
 
+  /@radix-ui/react-popper@1.1.2(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-1CnGGfFi/bbqtJZZ0P/NQY20xdG3E0LALJaLUEoKwPLwl6PPPfbeiCqMVQnhoFRAxjJj4RpBRJzDmUgsex2tSg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@floating-ui/react-dom': 2.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-use-rect': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/rect': 1.0.1
+      '@types/react': 18.2.7
+      '@types/react-dom': 18.2.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-portal@1.0.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-swu32idoCW7KA2VEiUZGBSu9nB6qwGdV6k6HYhUoOo3M1FFpD+VgLzUqtt3mwL1ssz7r2x8MggpLSQach2Xy/Q==}
     peerDependencies:
@@ -1801,6 +2090,27 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       '@radix-ui/react-primitive': 1.0.2(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-portal@1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-xLYZeHrWoPmA5mEKEfZZevoVRK/Q43GfzRXkWV6qawIWWK8t6ifIiLQdd7rmQ4Vk1bmI21XhqF9BN3jWf+phpA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.7
+      '@types/react-dom': 18.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -1818,6 +2128,28 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-presence@1.0.1(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
+      '@types/react-dom': 18.2.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-primitive@1.0.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==}
     peerDependencies:
@@ -1826,6 +2158,27 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       '@radix-ui/react-slot': 1.0.1(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-primitive@1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
+      '@types/react-dom': 18.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -1846,6 +2199,35 @@ packages:
       '@radix-ui/react-primitive': 1.0.2(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
       '@radix-ui/react-use-controllable-state': 1.0.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-roving-focus@1.0.4(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
+      '@types/react-dom': 18.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -1891,6 +2273,21 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-slot@1.0.2(@types/react@18.2.7)(react@18.2.0):
+    resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
       react: 18.2.0
     dev: false
 
@@ -1940,6 +2337,20 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.7)(react@18.2.0):
+    resolution: {integrity: sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@types/react': 18.2.7
+      react: 18.2.0
+    dev: false
+
   /@radix-ui/react-use-controllable-state@1.0.0(react@18.2.0):
     resolution: {integrity: sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==}
     peerDependencies:
@@ -1947,6 +2358,21 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.2.0)
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-controllable-state@1.0.1(@types/react@18.2.7)(react@18.2.0):
+    resolution: {integrity: sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
       react: 18.2.0
     dev: false
 
@@ -1960,12 +2386,41 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.2.7)(react@18.2.0):
+    resolution: {integrity: sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
+      react: 18.2.0
+    dev: false
+
   /@radix-ui/react-use-layout-effect@1.0.0(react@18.2.0):
     resolution: {integrity: sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@babel/runtime': 7.20.13
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.2.7)(react@18.2.0):
+    resolution: {integrity: sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@types/react': 18.2.7
       react: 18.2.0
     dev: false
 
@@ -1988,6 +2443,21 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@radix-ui/react-use-rect@1.0.1(@types/react@18.2.7)(react@18.2.0):
+    resolution: {integrity: sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/rect': 1.0.1
+      '@types/react': 18.2.7
+      react: 18.2.0
+    dev: false
+
   /@radix-ui/react-use-size@1.0.0(react@18.2.0):
     resolution: {integrity: sha512-imZ3aYcoYCKhhgNpkNDh/aTiU05qw9hX+HHI1QDBTyIlcFjgeFlKKySNGMwTp7nYFLQg/j0VA2FmCY4WPDDHMg==}
     peerDependencies:
@@ -1995,6 +2465,21 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       '@radix-ui/react-use-layout-effect': 1.0.0(react@18.2.0)
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-size@1.0.1(@types/react@18.2.7)(react@18.2.0):
+    resolution: {integrity: sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.7)(react@18.2.0)
+      '@types/react': 18.2.7
       react: 18.2.0
     dev: false
 
@@ -2012,6 +2497,12 @@ packages:
 
   /@radix-ui/rect@1.0.0:
     resolution: {integrity: sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==}
+    dependencies:
+      '@babel/runtime': 7.20.13
+    dev: false
+
+  /@radix-ui/rect@1.0.1:
+    resolution: {integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==}
     dependencies:
       '@babel/runtime': 7.20.13
     dev: false
@@ -2579,7 +3070,6 @@ packages:
     resolution: {integrity: sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==}
     dependencies:
       '@types/react': 18.2.7
-    dev: true
 
   /@types/react-transition-group@4.4.5:
     resolution: {integrity: sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -114,9 +114,11 @@ function generateTLSCert() {
 
     if ! openssl req -x509 -newkey rsa:4096 -keyout traefik/tls/key.pem -out traefik/tls/cert.pem -days 365 -subj "/O=runtipi.io/OU=IT/CN=*.${domain}/emailAddress=webmaster@${domain}" -addext "subjectAltName = DNS:*.${domain},DNS:${domain}" -nodes; then
         echo "Failed to generate TLS certificate"
+    else
+        echo "TLS certificate generated"
+        # Create a file to indicate that the certificate has been generated for this domain
+        touch "traefik/tls/$domain.txt"
     fi
-    # Create a file to indicate that the certificate has been generated for this domain
-    touch "traefik/tls/$domain.txt"
 }
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -79,19 +79,22 @@ mkdir -p app-data
 mkdir -p state
 mkdir -p repos
 
+mkdir -p traefik/shared
+mkdir -p traefik/tls
+
 mkdir -p media/torrents
 mkdir -p media/torrents/watch
-mkdir -p media/torrents/completed
+mkdir -p media/torrents/complete
 mkdir -p media/torrents/incomplete
 
 mkdir -p media/usenet
 mkdir -p media/usenet/watch
-mkdir -p media/usenet/completed
+mkdir -p media/usenet/complete
 mkdir -p media/usenet/incomplete
 
 mkdir -p media/downloads
 mkdir -p media/downloads/watch
-mkdir -p media/downloads/completed
+mkdir -p media/downloads/complete
 mkdir -p media/downloads/incomplete
 
 mkdir -p media/data

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -24,7 +24,7 @@ apps_repository="https://github.com/meienberger/runtipi-appstore"
 env_variables_json=$(cat <<EOF
 {
   "dns_ip": "9.9.9.9",
-  "domain": "tipi.localhost",
+  "domain": "example.com",
   "root_folder": "${ROOT_FOLDER}",
   "nginx_port": 3000,
   "nginx_port_ssl": 443,
@@ -38,6 +38,7 @@ env_variables_json=$(cat <<EOF
   "tipi_version": "$(get_json_field "${ROOT_FOLDER}/package.json" version)",
   "internal_ip": "localhost",
   "demo_mode": false,
+  "local_domain": "tipi.lan",
   "apps_repository": "${apps_repository}",
   "storage_path": "${ROOT_FOLDER}",
   "repo_id": "$("${ROOT_FOLDER}"/scripts/git.sh get_hash ${apps_repository})"

--- a/scripts/start-e2e.sh
+++ b/scripts/start-e2e.sh
@@ -28,6 +28,10 @@ sudo "${ROOT_FOLDER}/scripts/configure.sh"
 mkdir -p "${ROOT_FOLDER}/state"
 STATE_FOLDER="${ROOT_FOLDER}/state"
 
+mkdir -p traefik
+mkdir -p traefik/shared
+mkdir -p traefik/tls
+
 if [[ ! -f "${STATE_FOLDER}/seed" ]]; then
   echo "Generating seed..."
   mkdir -p "${STATE_FOLDER}"

--- a/scripts/start-e2e.sh
+++ b/scripts/start-e2e.sh
@@ -46,7 +46,7 @@ apps_repository="https://github.com/meienberger/runtipi-appstore"
 env_variables_json=$(cat <<EOF
 {
   "dns_ip": "9.9.9.9",
-  "domain": "tipi.localhost",
+  "domain": "example.com",
   "root_folder": "${ROOT_FOLDER}",
   "nginx_port": 80,
   "nginx_port_ssl": 443,
@@ -57,6 +57,7 @@ env_variables_json=$(cat <<EOF
   "postgres_port": 5432,
   "postgres_host": "tipi-db",
   "redis_host": "tipi-redis",
+  "local_domain": "tipi.lan",
   "tipi_version": "$(get_json_field "${ROOT_FOLDER}/package.json" version)",
   "internal_ip": "localhost",
   "demo_mode": false,

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -100,9 +100,10 @@ env_variables_json=$(cat <<EOF
   "postgres_port": 5432,
   "postgres_host": "tipi-db",
   "redis_host": "tipi-redis",
+  "local_domain": "tipi.lan",
   "repo_id": "$("${ROOT_FOLDER}"/scripts/git.sh get_hash "${apps_repository}")",
   "apps_repository": "${apps_repository}",
-  "domain": "tipi.localhost",
+  "domain": "tipi.lan",
   "storage_path": "${ROOT_FOLDER}",
   "demo_mode": false,
 }

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -103,7 +103,7 @@ env_variables_json=$(cat <<EOF
   "local_domain": "tipi.lan",
   "repo_id": "$("${ROOT_FOLDER}"/scripts/git.sh get_hash "${apps_repository}")",
   "apps_repository": "${apps_repository}",
-  "domain": "tipi.lan",
+  "domain": "example.com",
   "storage_path": "${ROOT_FOLDER}",
   "demo_mode": false,
 }

--- a/src/@types/next.d.ts
+++ b/src/@types/next.d.ts
@@ -11,7 +11,9 @@ type SessionContent = {
 };
 
 declare module 'express-session' {
-  export type SessionData = SessionContent;
+  interface SessionData extends SessionContent {
+    userId?: number;
+  }
 }
 
 interface ExtendedGetServerSidePropsContext<Params, Preview> extends GetServerSidePropsContext<Params, Preview> {

--- a/src/client/components/ui/Button/Button.tsx
+++ b/src/client/components/ui/Button/Button.tsx
@@ -6,7 +6,7 @@ interface IProps {
   type?: 'submit' | 'reset' | 'button';
   disabled?: boolean;
   loading?: boolean;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   children: React.ReactNode;
   width?: number | null;
 }

--- a/src/client/components/ui/DropdownMenu/DropdownMenu.tsx
+++ b/src/client/components/ui/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import * as React from 'react';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { IconChevronRight } from '@tabler/icons-react';
+import clsx from 'clsx';
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger ref={ref} className={clsx('', inset && 'ps-8', className)} {...props}>
+    {children}
+    <IconChevronRight className="" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<React.ElementRef<typeof DropdownMenuPrimitive.SubContent>, React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>>(
+  ({ className, ...props }, ref) => <DropdownMenuPrimitive.SubContent ref={ref} className={clsx('', className)} {...props} />,
+);
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef<React.ElementRef<typeof DropdownMenuPrimitive.Content>, React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>>(
+  ({ className, sideOffset = 4, ...props }, ref) => (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content ref={ref} sideOffset={sideOffset} className={clsx('dropdown-menu d-block position-relative', className)} {...props} />
+    </DropdownMenuPrimitive.Portal>
+  ),
+);
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => <DropdownMenuPrimitive.Item ref={ref} className={clsx('dropdown-item cursor-pointer', inset && 'ps-1', className)} {...props} />);
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => <DropdownMenuPrimitive.Label ref={ref} className={clsx('dropdown-header', inset && 'pl-8', className)} {...props} />);
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuGroup };

--- a/src/client/components/ui/DropdownMenu/index.ts
+++ b/src/client/components/ui/DropdownMenu/index.ts
@@ -1,0 +1,1 @@
+export { DropdownMenu, DropdownMenuItem, DropdownMenuGroup, DropdownMenuLabel, DropdownMenuContent, DropdownMenuTrigger } from './DropdownMenu';

--- a/src/client/messages/en.json
+++ b/src/client/messages/en.json
@@ -247,6 +247,8 @@
       "apps-repo-hint": "URL to the apps repository.",
       "storage-path": "Storage path",
       "storage-path-hint": "Path to the storage directory. Keep empty for default (runtipi/app-data). Make sure it is an absolute path and that it exists",
+      "local-domain": "Local domain",
+      "local-domain-hint": "Domain name used for accessing apps in your local network. Your apps will be accessible at app-name.local-domain.",
       "submit": "Save",
       "user-settings-title": "User settings",
       "language": "Language",

--- a/src/client/messages/en.json
+++ b/src/client/messages/en.json
@@ -144,6 +144,7 @@
       "link": "Link",
       "website": "Website",
       "supported-arch": "Supported architectures",
+      "choose-open-method": "Choose open method",
       "categories": {
         "data": "Data",
         "network": "Network",

--- a/src/client/messages/en.json
+++ b/src/client/messages/en.json
@@ -253,7 +253,8 @@
       "submit": "Save",
       "user-settings-title": "User settings",
       "language": "Language",
-      "help-translate": "Help translate Tipi"
+      "help-translate": "Help translate Tipi",
+      "download-certificate": "Download certificate"
     },
     "security": {
       "tab-title": "Security",

--- a/src/client/mocks/handlers.ts
+++ b/src/client/mocks/handlers.ts
@@ -29,7 +29,7 @@ export const handlers = [
   getTRPCMock({
     path: ['system', 'getSettings'],
     type: 'query',
-    response: { internalIp: 'localhost', dnsIp: '1.1.1.1', appsRepoUrl: 'https://test.com/test', domain: 'tipi.localhost' },
+    response: { internalIp: 'localhost', dnsIp: '1.1.1.1', appsRepoUrl: 'https://test.com/test', domain: 'tipi.localhost', localDomain: 'tipi.lan' },
   }),
   getTRPCMock({
     path: ['system', 'updateSettings'],

--- a/src/client/modules/Apps/components/AppActions/AppActions.test.tsx
+++ b/src/client/modules/Apps/components/AppActions/AppActions.test.tsx
@@ -1,24 +1,28 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import React from 'react';
 import { AppActions } from './AppActions';
-import { cleanup, fireEvent, render, screen } from '../../../../../../tests/test-utils';
+import { cleanup, fireEvent, render, screen, waitFor, userEvent } from '../../../../../../tests/test-utils';
 import { AppInfo } from '../../../../core/types';
 
 afterEach(cleanup);
 
 describe('Test: AppActions', () => {
   const app = {
-    name: 'My App',
-    form_fields: [],
-    exposable: [],
+    id: 'test',
+    info: {
+      port: 3000,
+      id: 'test',
+      name: 'My App',
+      form_fields: [],
+      exposable: [],
+    },
   } as unknown as AppInfo;
 
   it('should call the callbacks when buttons are clicked', () => {
     // arrange
     const onStart = jest.fn();
     const onRemove = jest.fn();
-    // @ts-expect-error
-    render(<AppActions status="stopped" info={app} onStart={onStart} onUninstall={onRemove} />);
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions status="stopped" app={app} onStart={onStart} onUninstall={onRemove} />);
 
     // act
     const startButton = screen.getByRole('button', { name: 'Start' });
@@ -33,8 +37,8 @@ describe('Test: AppActions', () => {
 
   it('should render the correct buttons when app status is running', () => {
     // arrange
-    // @ts-expect-error
-    render(<AppActions status="running" info={app} />);
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions status="running" app={app} />);
 
     // assert
     expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
@@ -44,8 +48,8 @@ describe('Test: AppActions', () => {
 
   it('should render the correct buttons when app status is starting', () => {
     // arrange
-    // @ts-expect-error
-    render(<AppActions status="starting" info={app} />);
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions status="starting" app={app} />);
 
     // assert
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
@@ -54,8 +58,8 @@ describe('Test: AppActions', () => {
 
   it('should render the correct buttons when app status is stopping', () => {
     // arrange
-    // @ts-expect-error
-    render(<AppActions status="stopping" info={app} />);
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions status="stopping" app={app} />);
 
     // assert
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
@@ -64,8 +68,8 @@ describe('Test: AppActions', () => {
 
   it('should render the correct buttons when app status is removing', () => {
     // arrange
-    // @ts-expect-error
-    render(<AppActions status="uninstalling" info={app} />);
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions status="uninstalling" app={app} />);
 
     // assert
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
@@ -74,8 +78,8 @@ describe('Test: AppActions', () => {
 
   it('should render the correct buttons when app status is installing', () => {
     // arrange
-    // @ts-ignore
-    render(<AppActions status="installing" info={app} />);
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions status="installing" app={app} />);
 
     // assert
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
@@ -84,8 +88,8 @@ describe('Test: AppActions', () => {
 
   it('should render the correct buttons when app status is updating', () => {
     // arrange
-    // @ts-expect-error
-    render(<AppActions status="updating" info={app} />);
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions status="updating" app={app} />);
 
     // assert
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
@@ -94,10 +98,96 @@ describe('Test: AppActions', () => {
 
   it('should render the correct buttons when app status is missing', () => {
     // arrange
-    // @ts-expect-error
-    render(<AppActions status="missing" info={app} />);
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions status="missing" app={app} />);
 
     // assert
     expect(screen.getByRole('button', { name: 'Install' })).toBeInTheDocument();
+  });
+
+  it('should render update button if app is running and has an update available', () => {
+    // arrange
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions status="running" updateAvailable app={app} />);
+
+    // assert
+    expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
+  });
+
+  it('should render update button if app is stopped and has an update available', () => {
+    // arrange
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions status="stopped" updateAvailable app={app} />);
+
+    // assert
+    expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
+  });
+
+  it('should render domain button if app is running and has a domain', async () => {
+    // arrange
+    const appWithDomain = {
+      ...app,
+      exposed: true,
+      domain: 'myapp.example.com',
+    };
+    const openFn = jest.fn();
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions onOpen={openFn} status="running" app={appWithDomain} />);
+
+    // act
+    const openButton = screen.getByRole('button', { name: 'Open' });
+    userEvent.type(openButton, '{arrowdown}');
+    await waitFor(() => {
+      expect(screen.getByText(/myapp.example.com/)).toBeInTheDocument();
+    });
+    const domainButton = screen.getByText(/myapp.example.com/);
+
+    // assert
+    userEvent.click(domainButton);
+    await waitFor(() => {
+      expect(openFn).toHaveBeenCalledWith('domain');
+    });
+  });
+
+  it('should render local_domain open button', async () => {
+    // arrange
+    const openFn = jest.fn();
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions localDomain="tipi.lan" onOpen={openFn} status="running" app={app} />);
+
+    // act
+    const openButton = screen.getByRole('button', { name: 'Open' });
+    userEvent.type(openButton, '{arrowdown}');
+    await waitFor(() => {
+      expect(screen.getByText(/test.tipi.lan/)).toBeInTheDocument();
+    });
+    const localButton = screen.getByText(/test.tipi.lan/);
+
+    // assert
+    userEvent.click(localButton);
+    await waitFor(() => {
+      expect(openFn).toHaveBeenCalledWith('local_domain');
+    });
+  });
+
+  it('should render local open button', async () => {
+    // arrange
+    const openFn = jest.fn();
+    // @ts-expect-error - we don't need to pass all props for this test
+    render(<AppActions localUrl="http://localhost:3000" onOpen={openFn} status="running" app={app} />);
+
+    // act
+    const openButton = screen.getByRole('button', { name: 'Open' });
+    userEvent.type(openButton, '{arrowdown}');
+    await waitFor(() => {
+      expect(screen.getByText(/localhost:3000/)).toBeInTheDocument();
+    });
+    const localButton = screen.getByText(/localhost:3000/);
+
+    // assert
+    userEvent.click(localButton);
+    await waitFor(() => {
+      expect(openFn).toHaveBeenCalledWith('local');
+    });
   });
 });

--- a/src/client/modules/Apps/containers/AppDetailsContainer/AppDetailsContainer.test.tsx
+++ b/src/client/modules/Apps/containers/AppDetailsContainer/AppDetailsContainer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { faker } from '@faker-js/faker';
-import { fireEvent, render, screen, waitFor } from '../../../../../../tests/test-utils';
+import { fireEvent, render, screen, userEvent, waitFor } from '../../../../../../tests/test-utils';
 import { createAppEntity } from '../../../../mocks/fixtures/app.fixtures';
 import { getTRPCMock, getTRPCMockError } from '../../../../mocks/getTrpcMock';
 import { server } from '../../../../mocks/server';
@@ -86,10 +86,19 @@ describe('Test: AppDetailsContainer', () => {
 
       // Act
       const openButton = screen.getByRole('button', { name: 'Open' });
-      openButton.click();
+      userEvent.type(openButton, '{arrowdown}');
+      await waitFor(() => {
+        expect(screen.getByText(/localhost:/)).toBeInTheDocument();
+      });
+
+      const openButtonItem = screen.getByText(/localhost:/);
+      userEvent.click(openButtonItem);
 
       // Assert
-      expect(spy).toHaveBeenCalledWith(`http://localhost:${app.info.port}`, '_blank', 'noreferrer');
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(`http://localhost:${app.info.port}`, '_blank', 'noreferrer');
+      });
+      spy.mockRestore();
     });
 
     it('should open with https when app info has https set to true', async () => {
@@ -100,10 +109,20 @@ describe('Test: AppDetailsContainer', () => {
 
       // Act
       const openButton = screen.getByRole('button', { name: 'Open' });
-      openButton.click();
+      userEvent.type(openButton, '{arrowdown}');
+
+      await waitFor(() => {
+        expect(screen.getByText(/localhost:/)).toBeInTheDocument();
+      });
+
+      const openButtonItem = screen.getByText(/localhost:/);
+      userEvent.click(openButtonItem);
 
       // Assert
-      expect(spy).toHaveBeenCalledWith(`https://localhost:${app.info.port}`, '_blank', 'noreferrer');
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(`https://localhost:${app.info.port}`, '_blank', 'noreferrer');
+      });
+      spy.mockRestore();
     });
   });
 

--- a/src/client/modules/Apps/containers/AppDetailsContainer/AppDetailsContainer.test.tsx
+++ b/src/client/modules/Apps/containers/AppDetailsContainer/AppDetailsContainer.test.tsx
@@ -124,6 +124,54 @@ describe('Test: AppDetailsContainer', () => {
       });
       spy.mockRestore();
     });
+
+    it('should open with domain when domain is clicked', async () => {
+      // Arrange
+      const app = createAppEntity({ overrides: { domain: 'test.com', exposed: true } });
+      const spy = jest.spyOn(window, 'open').mockImplementation(() => null);
+      render(<AppDetailsContainer app={app} />);
+
+      // Act
+      const openButton = screen.getByRole('button', { name: 'Open' });
+      userEvent.type(openButton, '{arrowdown}');
+
+      await waitFor(() => {
+        expect(screen.getByText(/test.com/)).toBeInTheDocument();
+      });
+
+      const openButtonItem = screen.getByText(/test.com/);
+      userEvent.click(openButtonItem);
+
+      // Assert
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(`https://test.com`, '_blank', 'noreferrer');
+      });
+      spy.mockRestore();
+    });
+
+    it('should open with local domain when local domain is clicked', async () => {
+      // Arrange
+      const app = createAppEntity({});
+      const spy = jest.spyOn(window, 'open').mockImplementation(() => null);
+      render(<AppDetailsContainer app={app} />);
+
+      // Act
+      const openButton = screen.getByRole('button', { name: 'Open' });
+      userEvent.type(openButton, '{arrowdown}');
+
+      await waitFor(() => {
+        expect(screen.getByText(/.tipi.lan/)).toBeInTheDocument();
+      });
+
+      const openButtonItem = screen.getByText(/.tipi.lan/);
+      userEvent.click(openButtonItem);
+
+      // Assert
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(`https://${app.id}.tipi.lan`, '_blank', 'noreferrer');
+      });
+      spy.mockRestore();
+    });
   });
 
   describe('Test: Install app', () => {

--- a/src/client/modules/Settings/components/SettingsForm/SettingsForm.test.tsx
+++ b/src/client/modules/Settings/components/SettingsForm/SettingsForm.test.tsx
@@ -39,6 +39,7 @@ describe('Test: SettingsForm', () => {
       internalIp: 'invalid internal ip',
       appsRepoUrl: 'invalid url',
       storagePath: 'invalid path',
+      localDomain: 'invalid local domain',
     };
     render(<SettingsForm onSubmit={jest.fn()} submitErrors={submitErrors} />);
 
@@ -50,6 +51,7 @@ describe('Test: SettingsForm', () => {
     expect(screen.getByText(submitErrors.internalIp)).toBeInTheDocument();
     expect(screen.getByText(submitErrors.appsRepoUrl)).toBeInTheDocument();
     expect(screen.getByText(submitErrors.storagePath)).toBeInTheDocument();
+    expect(screen.getByText(submitErrors.localDomain)).toBeInTheDocument();
   });
 
   it('should correctly validate the form', async () => {
@@ -60,19 +62,21 @@ describe('Test: SettingsForm', () => {
     const domainInput = screen.getByRole('textbox', { name: 'domain' });
     const internalIpInput = screen.getByRole('textbox', { name: 'internalIp' });
     const appsRepoUrlInput = screen.getByRole('textbox', { name: 'appsRepoUrl' });
+    const localDomainInput = screen.getByRole('textbox', { name: 'localDomain' });
 
     // act
     fireEvent.change(dnsIpInput, { target: { value: 'invalid ip' } });
     fireEvent.change(domainInput, { target: { value: 'invalid domain' } });
     fireEvent.change(internalIpInput, { target: { value: 'invalid internal ip' } });
     fireEvent.change(appsRepoUrlInput, { target: { value: 'invalid url' } });
+    fireEvent.change(localDomainInput, { target: { value: 'invalid local domain' } });
     fireEvent.click(submitButton);
 
     // assert
     await waitFor(() => {
       expect(screen.getAllByText('Invalid IP address')).toHaveLength(2);
     });
-    expect(screen.getByText('Invalid domain')).toBeInTheDocument();
+    expect(screen.getAllByText('Invalid domain')).toHaveLength(2);
     expect(screen.getByText('Invalid URL')).toBeInTheDocument();
   });
 
@@ -88,6 +92,21 @@ describe('Test: SettingsForm', () => {
     // assert
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should download the certificate when the download button is clicked', async () => {
+    // arrange
+    const spy = jest.spyOn(window, 'open').mockImplementation();
+    render(<SettingsForm onSubmit={jest.fn} />);
+    const downloadButton = screen.getByRole('button', { name: 'Download certificate' });
+
+    // act
+    fireEvent.click(downloadButton);
+
+    // assert
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/client/modules/Settings/components/SettingsForm/SettingsForm.test.tsx
+++ b/src/client/modules/Settings/components/SettingsForm/SettingsForm.test.tsx
@@ -56,10 +56,10 @@ describe('Test: SettingsForm', () => {
     // arrange
     render(<SettingsForm onSubmit={jest.fn()} />);
     const submitButton = screen.getByRole('button', { name: 'Save' });
-    const dnsIpInput = screen.getByLabelText('DNS IP');
-    const domainInput = screen.getByLabelText('Domain name');
-    const internalIpInput = screen.getByLabelText('Internal IP');
-    const appsRepoUrlInput = screen.getByLabelText('Apps repo URL');
+    const dnsIpInput = screen.getByRole('textbox', { name: 'dnsIp' });
+    const domainInput = screen.getByRole('textbox', { name: 'domain' });
+    const internalIpInput = screen.getByRole('textbox', { name: 'internalIp' });
+    const appsRepoUrlInput = screen.getByRole('textbox', { name: 'appsRepoUrl' });
 
     // act
     fireEvent.change(dnsIpInput, { target: { value: 'invalid ip' } });

--- a/src/client/modules/Settings/components/SettingsForm/SettingsForm.tsx
+++ b/src/client/modules/Settings/components/SettingsForm/SettingsForm.tsx
@@ -183,9 +183,8 @@ export const SettingsForm = (props: IProps) => {
             error={errors.localDomain?.message}
             placeholder="tipi.lan"
           />
-
           <Button className="mt-2" onClick={downloadCertificate}>
-            Download certificate
+            {t('download-certificate')}
           </Button>
         </div>
         <Button loading={loading} type="submit" className="btn-success">

--- a/src/client/modules/Settings/components/SettingsForm/SettingsForm.tsx
+++ b/src/client/modules/Settings/components/SettingsForm/SettingsForm.tsx
@@ -100,7 +100,7 @@ export const SettingsForm = (props: IProps) => {
         </div>
         <p className="mb-4">{t('subtitle')}</p>
         <div className="mb-3">
-          <Input {...register('domain')} label={t('domain-name')} error={errors.domain?.message} placeholder="tipi.localhost" />
+          <Input {...register('domain')} label={t('domain-name')} error={errors.domain?.message} placeholder="example.com" />
           <span className="text-muted">{t('domain-name-hint')}</span>
         </div>
         <div className="mb-3">

--- a/src/client/modules/Settings/components/SettingsForm/SettingsForm.tsx
+++ b/src/client/modules/Settings/components/SettingsForm/SettingsForm.tsx
@@ -2,9 +2,11 @@ import { LanguageSelector } from '@/components/LanguageSelector';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { IconAdjustmentsAlt, IconUser } from '@tabler/icons-react';
+import clsx from 'clsx';
 import { useTranslations } from 'next-intl';
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
+import { Tooltip } from 'react-tooltip';
 import validator from 'validator';
 
 export type SettingsFormValues = {
@@ -13,6 +15,7 @@ export type SettingsFormValues = {
   appsRepoUrl?: string;
   domain?: string;
   storagePath?: string;
+  localDomain?: string;
 };
 
 interface IProps {
@@ -28,6 +31,10 @@ export const SettingsForm = (props: IProps) => {
 
   const validateFields = (values: SettingsFormValues) => {
     const errors: { [K in keyof SettingsFormValues]?: string } = {};
+
+    if (values.localDomain && !validator.isFQDN(values.localDomain)) {
+      errors.localDomain = t('invalid-domain');
+    }
 
     if (values.dnsIp && !validator.isIP(values.dnsIp)) {
       errors.dnsIp = t('invalid-ip');
@@ -86,6 +93,11 @@ export const SettingsForm = (props: IProps) => {
     }
   };
 
+  const downloadCertificate = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    window.open('/certificate');
+  };
+
   return (
     <>
       <div className="d-flex">
@@ -100,23 +112,81 @@ export const SettingsForm = (props: IProps) => {
         </div>
         <p className="mb-4">{t('subtitle')}</p>
         <div className="mb-3">
-          <Input {...register('domain')} label={t('domain-name')} error={errors.domain?.message} placeholder="example.com" />
-          <span className="text-muted">{t('domain-name-hint')}</span>
+          <Input
+            {...register('domain')}
+            label={
+              <>
+                {t('domain-name')}
+                <Tooltip anchorSelect=".domain-name-hint">{t('domain-name-hint')}</Tooltip>
+                <span className={clsx('ms-1 form-help domain-name-hint')}>?</span>
+              </>
+            }
+            error={errors.domain?.message}
+            placeholder="example.com"
+          />
         </div>
         <div className="mb-3">
           <Input {...register('dnsIp')} label={t('dns-ip')} error={errors.dnsIp?.message} placeholder="9.9.9.9" />
         </div>
         <div className="mb-3">
-          <Input {...register('internalIp')} label={t('internal-ip')} error={errors.internalIp?.message} placeholder="192.168.1.100" />
-          <span className="text-muted">{t('internal-ip-hint')}</span>
+          <Input
+            {...register('internalIp')}
+            label={
+              <>
+                {t('internal-ip')}
+                <Tooltip anchorSelect=".internal-ip-hint">{t('internal-ip-hint')}</Tooltip>
+                <span className={clsx('ms-1 form-help internal-ip-hint')}>?</span>
+              </>
+            }
+            error={errors.internalIp?.message}
+            placeholder="192.168.1.100"
+          />
         </div>
         <div className="mb-3">
-          <Input {...register('appsRepoUrl')} label={t('apps-repo')} error={errors.appsRepoUrl?.message} placeholder="https://github.com/meienberger/runtipi-appstore" />
-          <span className="text-muted">{t('apps-repo-hint')}</span>
+          <Input
+            {...register('appsRepoUrl')}
+            label={
+              <>
+                {t('apps-repo')}
+                <Tooltip anchorSelect=".apps-repo-hint">{t('apps-repo-hint')}</Tooltip>
+                <span className={clsx('ms-1 form-help apps-repo-hint')}>?</span>
+              </>
+            }
+            error={errors.appsRepoUrl?.message}
+            placeholder="https://github.com/meienberger/runtipi-appstore"
+          />
         </div>
         <div className="mb-3">
-          <Input {...register('storagePath')} label={t('storage-path')} error={errors.storagePath?.message} placeholder={t('storage-path')} />
-          <span className="text-muted">{t('storage-path-hint')}</span>
+          <Input
+            {...register('storagePath')}
+            label={
+              <>
+                {t('storage-path')}
+                <Tooltip anchorSelect=".storage-path-hint">{t('storage-path-hint')}</Tooltip>
+                <span className={clsx('ms-1 form-help storage-path-hint')}>?</span>
+              </>
+            }
+            error={errors.storagePath?.message}
+            placeholder={t('storage-path')}
+          />
+        </div>
+        <div className="mb-3">
+          <Input
+            {...register('localDomain')}
+            label={
+              <>
+                {t('local-domain')}
+                <Tooltip anchorSelect=".local-domain-hint">{t('local-domain-hint')}</Tooltip>
+                <span className={clsx('ms-1 form-help local-domain-hint')}>?</span>
+              </>
+            }
+            error={errors.localDomain?.message}
+            placeholder="tipi.lan"
+          />
+
+          <Button className="mt-2" onClick={downloadCertificate}>
+            Download certificate
+          </Button>
         </div>
         <Button loading={loading} type="submit" className="btn-success">
           {t('submit')}

--- a/src/server/core/TipiConfig/TipiConfig.ts
+++ b/src/server/core/TipiConfig/TipiConfig.ts
@@ -24,6 +24,7 @@ const configSchema = z.object({
   appsRepoId: z.string(),
   appsRepoUrl: z.string().url().trim(),
   domain: z.string().trim(),
+  localDomain: z.string().trim(),
   storagePath: z
     .string()
     .trim()
@@ -47,7 +48,7 @@ const configSchema = z.object({
     }),
 });
 
-export const settingsSchema = configSchema.partial().pick({ dnsIp: true, internalIp: true, appsRepoUrl: true, domain: true, storagePath: true });
+export const settingsSchema = configSchema.partial().pick({ dnsIp: true, internalIp: true, appsRepoUrl: true, domain: true, storagePath: true, localDomain: true });
 
 type TipiSettingsType = z.infer<typeof settingsSchema>;
 
@@ -80,6 +81,7 @@ export class TipiConfig {
       appsRepoId: conf.APPS_REPO_ID,
       appsRepoUrl: conf.APPS_REPO_URL,
       domain: conf.DOMAIN,
+      localDomain: conf.LOCAL_DOMAIN,
       dnsIp: conf.DNS_IP || '9.9.9.9',
       status: 'RUNNING',
       storagePath: conf.STORAGE_PATH,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable global-require */
-import express from 'express';
+import express, { Request } from 'express';
 import { parse } from 'url';
 
 import type { NextServer } from 'next/dist/server/next';
@@ -11,6 +11,7 @@ import { runPostgresMigrations } from './run-migration';
 import { AppServiceClass } from './services/apps/apps.service';
 import { db } from './db';
 import { sessionMiddleware } from './middlewares/session.middleware';
+import { AuthQueries } from './queries/auth/auth.queries';
 
 let conf = {};
 let nextApp: NextServer;
@@ -33,11 +34,25 @@ const handle = nextApp.getRequestHandler();
 
 nextApp.prepare().then(async () => {
   const app = express();
+  const authService = new AuthQueries(db);
+
   app.disable('x-powered-by');
 
   app.use(sessionMiddleware);
 
   app.use('/static', express.static(`${getConfig().rootFolder}/repos/${getConfig().appsRepoId}/`));
+
+  app.use('/certificate', async (req, res) => {
+    const userId = req.session?.userId;
+    const user = await authService.getUserById(userId);
+
+    if (user?.operator) {
+      res.setHeader('Content-Dispositon', 'attachment; filename=cert.pem');
+      return res.sendFile(`${getConfig().rootFolder}/traefik/tls/cert.pem`);
+    }
+
+    return res.status(403).send('Forbidden');
+  });
 
   app.all('*', (req, res) => {
     const parsedUrl = parse(req.url, true);
@@ -50,7 +65,7 @@ nextApp.prepare().then(async () => {
     EventDispatcher.clear();
 
     // Run database migrations
-    if (getConfig().NODE_ENV !== 'development') {
+    if (getConfig().NODE_ENV === 'development') {
       await runPostgresMigrations();
     }
     setConfig('status', 'RUNNING');

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable global-require */
-import express, { Request } from 'express';
+import express from 'express';
 import { parse } from 'url';
 
 import type { NextServer } from 'next/dist/server/next';
@@ -44,7 +44,7 @@ nextApp.prepare().then(async () => {
 
   app.use('/certificate', async (req, res) => {
     const userId = req.session?.userId;
-    const user = await authService.getUserById(userId);
+    const user = await authService.getUserById(userId as number);
 
     if (user?.operator) {
       res.setHeader('Content-Dispositon', 'attachment; filename=cert.pem');

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -65,7 +65,7 @@ nextApp.prepare().then(async () => {
     EventDispatcher.clear();
 
     // Run database migrations
-    if (getConfig().NODE_ENV === 'development') {
+    if (getConfig().NODE_ENV !== 'development') {
       await runPostgresMigrations();
     }
     setConfig('status', 'RUNNING');

--- a/src/server/services/apps/apps.helpers.ts
+++ b/src/server/services/apps/apps.helpers.ts
@@ -179,7 +179,7 @@ export const generateEnvFile = (app: App) => {
   }
 
   const baseEnvFile = readFile('/runtipi/.env').toString();
-  let envFile = `${baseEnvFile}\nAPP_PORT=${parsedConfig.data.port}\n`;
+  let envFile = `${baseEnvFile}\nAPP_PORT=${parsedConfig.data.port}\nAPP_ID=${app.id}\n`;
   const envMap = getEnvMap(app.id);
 
   if (parsedConfig.data.generate_vapid_keys) {
@@ -330,7 +330,7 @@ export const getAppInfo = (id: string, status?: App['status']) => {
  *  If the app folder does not exist, it copies the app folder from the apps repository.
  *
  *  @param {string} appName - The name of the app.
- *  @param {boolean} [cleanup=false] - A flag indicating whether to cleanup the app folder before ensuring its existence.
+ *  @param {boolean} [cleanup] - A flag indicating whether to cleanup the app folder before ensuring its existence.
  *  @throws Will throw an error if the app folder cannot be copied from the repository
  */
 export const ensureAppFolder = (appName: string, cleanup = false): void => {

--- a/src/server/services/apps/apps.service.test.ts
+++ b/src/server/services/apps/apps.service.test.ts
@@ -40,7 +40,7 @@ describe('Install app', () => {
     const envFile = fs.readFileSync(`/app/storage/app-data/${appConfig.id}/app.env`).toString();
 
     // assert
-    expect(envFile.trim()).toBe(`TEST=test\nAPP_PORT=${appConfig.port}\nTEST_FIELD=test\nAPP_DOMAIN=localhost:${appConfig.port}`);
+    expect(envFile.trim()).toBe(`TEST=test\nAPP_PORT=${appConfig.port}\nAPP_ID=${appConfig.id}\nTEST_FIELD=test\nAPP_DOMAIN=localhost:${appConfig.port}`);
   });
 
   it('Should add app in database', async () => {
@@ -336,7 +336,7 @@ describe('Start app', () => {
     const envFile = fs.readFileSync(`/app/storage/app-data/${appConfig.id}/app.env`).toString();
 
     // assert
-    expect(envFile.trim()).toBe(`TEST=test\nAPP_PORT=${appConfig.port}\nTEST_FIELD=test\nAPP_DOMAIN=localhost:${appConfig.port}`);
+    expect(envFile.trim()).toBe(`TEST=test\nAPP_PORT=${appConfig.port}\nAPP_ID=${appConfig.id}\nTEST_FIELD=test\nAPP_DOMAIN=localhost:${appConfig.port}`);
   });
 
   it('Should throw if start script fails', async () => {
@@ -395,7 +395,7 @@ describe('Update app config', () => {
     const envFile = fs.readFileSync(`/app/storage/app-data/${appConfig.id}/app.env`).toString();
 
     // assert
-    expect(envFile.trim()).toBe(`TEST=test\nAPP_PORT=${appConfig.port}\nTEST_FIELD=${word}\nAPP_DOMAIN=localhost:${appConfig.port}`);
+    expect(envFile.trim()).toBe(`TEST=test\nAPP_PORT=${appConfig.port}\nAPP_ID=${appConfig.id}\nTEST_FIELD=${word}\nAPP_DOMAIN=localhost:${appConfig.port}`);
   });
 
   it('Should throw if required field is missing', async () => {

--- a/src/server/services/apps/apps.service.ts
+++ b/src/server/services/apps/apps.service.ts
@@ -185,7 +185,7 @@ export class AppServiceClass {
    *
    * @param {string} id - The ID of the app to update.
    * @param {object} form - The new configuration of the app.
-   * @param {boolean} [exposed=false] - If the app should be exposed or not.
+   * @param {boolean} [exposed] - If the app should be exposed or not.
    * @param {string} [domain] - The domain for the app if exposed is true.
    */
   public updateAppConfig = async (id: string, form: Record<string, string>, exposed?: boolean, domain?: string) => {

--- a/templates/env-sample
+++ b/templates/env-sample
@@ -21,4 +21,5 @@ POSTGRES_PASSWORD=<postgres_password>
 POSTGRES_PORT=<postgres_port>
 REDIS_HOST=<redis_host>
 DEMO_MODE=<demo_mode>
+LOCAL_DOMAIN=<local_domain>
 DOCKER_TAG=<docker_tag>

--- a/tests/client/jest.setup.tsx
+++ b/tests/client/jest.setup.tsx
@@ -18,6 +18,8 @@ class ResizeObserver {
   observe() {}
 
   unobserve() {}
+
+  disconnect() {}
 }
 
 // Mock localStorage
@@ -41,6 +43,8 @@ const localStorageMock = (() => {
 
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 Object.defineProperty(window, 'ResizeObserver', { value: ResizeObserver });
+Object.defineProperty(window, 'MutationObserver', { value: ResizeObserver });
+
 Object.defineProperty(window, 'matchMedia', {
   value: () => {
     return {

--- a/tests/test-utils.tsx
+++ b/tests/test-utils.tsx
@@ -2,8 +2,11 @@ import React, { FC, ReactElement } from 'react';
 import { render, RenderOptions, renderHook } from '@testing-library/react';
 import { Toaster } from 'react-hot-toast';
 import { NextIntlProvider } from 'next-intl';
+import ue from '@testing-library/user-event';
 import { TRPCTestClientProvider } from './TRPCTestClientProvider';
 import messages from '../src/client/messages/en.json';
+
+const userEvent = ue.setup();
 
 const AllTheProviders: FC<{ children: React.ReactNode }> = ({ children }) => (
   <NextIntlProvider locale="en" messages={messages}>
@@ -20,3 +23,4 @@ const customRenderHook = (callback: () => any, options?: Omit<RenderOptions, 'wr
 export * from '@testing-library/react';
 export { customRender as render };
 export { customRenderHook as renderHook };
+export { userEvent };

--- a/traefik/dynamic/dynamic.yml
+++ b/traefik/dynamic/dynamic.yml
@@ -2,3 +2,13 @@ http:
   serversTransports:
     insecuretransport:
       insecureSkipVerify: true
+
+tls:
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /root/.config/tls/cert.pem
+        keyFile: /root/.config/tls/key.pem
+  certificates:
+    - certFile: /root/.config/tls/cert.pem
+      keyFile: /root/.config/tls/key.pem


### PR DESCRIPTION
## Purpose
As a user, I want to visit my installed apps using a local domain like `tipi.lan` and my installed app on a subdomain like `myapp.tipi.lan`. This way I don't have to remember ips an ports and also I can use an HTTPS connection.
