### PR TITLE
Modify configure.sh to try using an AUR helper

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -20,7 +20,14 @@ function install_generic() {
     sudo dnf -y install "${dependency}"
     return 0
   elif [[ "${os}" == "arch" ]]; then
-    sudo pacman -Sy --noconfirm "${dependency}"
+    if ! sudo pacman -Sy --noconfirm "${dependency}" ; then
+      if command -v yay > /dev/null 2>&1 ; then
+        sudo -u $SUDO_USER yay -Sy --noconfirm "${dependency}"
+      else
+        echo "Could not install \"${dependency}\", either using pacman or the yay AUR helper. Please try installing it manually."
+        return 1
+      fi
+    fi
     return 0
   else
     return 1


### PR DESCRIPTION
When installing packages, if `pacman` doesn't find a package in any of `pacman`'s repositories, try installing the package from the AUR using `yay`.

On Arch Linux, some packages are not available through the `pacman` package manager (I'm looking at you, `fswatch`). Thus we should try to install it from the AUR using the `yay` AUR helper, and if `yay` is not found (there are other AUR helpers, yay is just the most common) alert the user to try to install the offending package manually.