### PR TITLE
fix: settings like port getting deleted on save 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@hookform/resolvers':
     specifier: ^3.1.1
@@ -3496,7 +3492,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.2
+      semver: 7.5.3
       tsutils: 3.21.0(typescript@5.1.3)
       typescript: 5.1.3
     transitivePeerDependencies:
@@ -10315,3 +10311,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/src/server/core/TipiConfig/TipiConfig.ts
+++ b/src/server/core/TipiConfig/TipiConfig.ts
@@ -48,7 +48,10 @@ const configSchema = z.object({
     }),
 });
 
-export const settingsSchema = configSchema.partial().pick({ dnsIp: true, internalIp: true, appsRepoUrl: true, domain: true, storagePath: true, localDomain: true });
+export const settingsSchema = configSchema
+  .partial()
+  .pick({ dnsIp: true, internalIp: true, appsRepoUrl: true, domain: true, storagePath: true, localDomain: true })
+  .and(z.object({ port: z.number(), sslPort: z.number(), listenIp: z.string().ip().trim() }).partial());
 
 type TipiSettingsType = z.infer<typeof settingsSchema>;
 

--- a/src/server/routers/system/system.router.ts
+++ b/src/server/routers/system/system.router.ts
@@ -13,6 +13,6 @@ export const systemRouter = router({
   getVersion: publicProcedure.query(SystemService.getVersion),
   restart: protectedProcedure.mutation(SystemService.restart),
   update: protectedProcedure.mutation(SystemService.update),
-  updateSettings: protectedProcedure.input(settingsSchema.partial()).mutation(({ input }) => TipiConfig.setSettings(input)),
+  updateSettings: protectedProcedure.input(settingsSchema).mutation(({ input }) => TipiConfig.setSettings(input)),
   getSettings: protectedProcedure.query(TipiConfig.getSettings),
 });


### PR DESCRIPTION
## Purpose
When a setting is not used by the app (eg, port), it gets overridden when saving settings. Because the Zod schema doesn't allow it.

## Changes
Add all non-functional settings to the setting schema to not delete those when saving settings