### PR TITLE
Fix OS detection on Linux Mint

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -36,9 +36,9 @@ while [ -n "${1-}" ]; do
     shift
 done
 
-
-OS="$(find /etc -maxdepth 1 -type f,l -name '[A-Za-z]*[_-][rv]e[lr]*' | xargs cat | grep "^ID=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
-SUB_OS="$(find /etc -maxdepth 1 -type f,l -name '[A-Za-z]*[_-][rv]e[lr]*' | xargs cat | grep "^ID_LIKE=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"' || echo 'unknown')"
+OS_CONFIG="$(find /etc -maxdepth 1 -type f,l -name '[A-Za-z]*[_-][rv]e[lr]*' | xargs cat)"
+OS="$(echo $OS_CONFIG | grep "^ID=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
+SUB_OS="$(echo $OS_CONFIG | grep "^ID_LIKE=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"' || echo 'unknown')"
 
 function install_generic() {
   local dependency="${1}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,8 +37,8 @@ while [ -n "${1-}" ]; do
 done
 
 
-OS="$(cat /etc/[A-Za-z]*[_-][rv]e[lr]* | grep "^ID=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
-SUB_OS="$(cat /etc/[A-Za-z]*[_-][rv]e[lr]* | grep "^ID_LIKE=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"' || echo 'unknown')"
+OS="$(find /etc -maxdepth 1 -type f,l -name '[A-Za-z]*[_-][rv]e[lr]*' | xargs cat | grep "^ID=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"')"
+SUB_OS="$(find /etc -maxdepth 1 -type f,l -name '[A-Za-z]*[_-][rv]e[lr]*' | xargs cat | grep "^ID_LIKE=" | cut -d= -f2 | uniq | tr '[:upper:]' '[:lower:]' | tr -d '"' || echo 'unknown')"
 
 function install_generic() {
   local dependency="${1}"


### PR DESCRIPTION
On Mint Linux the previous command version doesn't work quite right.

If I do `ls -l /etc/[A-Za-z]*[_-][rv]e[lr]*` it returns:
```
-rw-r--r-- 1 root   13 aug 22  2021 /etc/debian_version
-rw-r--r-- 1 root  115 jun  6 11:51 /etc/lsb-release
lrwxrwxrwx 1 root   21 aug 25 15:26 /etc/os-release -> ../usr/lib/os-release

/etc/upstream-release:
total 4
-rw-r--r-- 1 root 108 jul  4  2022 lsb-release
```

This then makes the script error out at the OS step with `cat: /etc/upstream-release: Is a directory`.

I fixed it by using `find` to get only files and symlinks one level down in `/etc` and then piping that to `cat`.