### PR TITLE
fix(cli): mark app store repo as git safe folder before pulling

### DIFF
--- a/packages/cli/src/executors/repo/repo.executors.ts
+++ b/packages/cli/src/executors/repo/repo.executors.ts
@@ -75,6 +75,7 @@ export class RepoExecutors {
 
       this.logger.info(`Pulling repo ${repoUrl} to ${repoPath}`);
 
+      await execAsync(`git config --global --add safe.directory ${repoPath}`);
       const { stdout, stderr } = await execAsync(`git -C ${repoPath} pull`);
 
       if (stderr) {


### PR DESCRIPTION
## Purpose

A bug can happen to some user where git is signaling that the repo is not safe to pull. 
```
fatal: detected dubious ownership in repository at 
```
This PR adds an exception to the cloned repo