### PR TITLE
fix: app files permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtipi",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A homeserver for everyone",
   "scripts": {
     "knip": "knip",

--- a/packages/cli/.env.test
+++ b/packages/cli/.env.test
@@ -5,4 +5,4 @@ APPS_REPO_URL=https://test.com/test
 ROOT_FOLDER_HOST=/runtipi
 STORAGE_PATH=/runtipi
 TIPI_VERSION=1
-
+REDIS_PASSWORD=redis

--- a/packages/cli/src/executors/app/app.executors.ts
+++ b/packages/cli/src/executors/app/app.executors.ts
@@ -168,10 +168,14 @@ export class AppExecutors {
       await compose(appId, 'down --remove-orphans --volumes --rmi all');
 
       this.logger.info(`Deleting folder ${appDirPath}`);
-      await fs.promises.rm(appDirPath, { recursive: true, force: true });
+      await fs.promises.rm(appDirPath, { recursive: true, force: true }).catch((err) => {
+        this.logger.error(`Error deleting folder ${appDirPath}: ${err.message}`);
+      });
 
       this.logger.info(`Deleting folder ${appDataDirPath}`);
-      await fs.promises.rm(appDataDirPath, { recursive: true, force: true });
+      await fs.promises.rm(appDataDirPath, { recursive: true, force: true }).catch((err) => {
+        this.logger.error(`Error deleting folder ${appDataDirPath}: ${err.message}`);
+      });
 
       this.logger.info(`App ${appId} uninstalled`);
       return { success: true, message: `App ${appId} uninstalled successfully` };

--- a/packages/cli/src/executors/app/app.executors.ts
+++ b/packages/cli/src/executors/app/app.executors.ts
@@ -62,10 +62,15 @@ export class AppExecutors {
    */
   public installApp = async (appId: string, config: Record<string, unknown>) => {
     try {
+      if (process.getuid && process.getgid) {
+        this.logger.info(`Installing app ${appId} as User ID: ${process.getuid()}, Group ID: ${process.getgid()}`);
+      } else {
+        this.logger.info(`Installing app ${appId}. No User ID or Group ID found.`);
+      }
+
       const { rootFolderHost, appsRepoId } = getEnv();
 
       const { appDirPath, repoPath, appDataDirPath } = this.getAppPaths(appId);
-      this.logger.info(`Installing app ${appId}`);
 
       // Check if app exists in repo
       const apps = await fs.promises.readdir(path.join(rootFolderHost, 'repos', appsRepoId, 'apps'));

--- a/packages/cli/src/executors/app/app.helpers.ts
+++ b/packages/cli/src/executors/app/app.helpers.ts
@@ -2,9 +2,13 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { appInfoSchema, envMapToString, envStringToMap } from '@runtipi/shared';
+import { exec } from 'child_process';
+import { promisify } from 'util';
 import { getEnv } from '@/utils/environment/environment';
 import { generateVapidKeys, getAppEnvMap } from './env.helpers';
 import { pathExists } from '@/utils/fs-helpers';
+
+const execAsync = promisify(exec);
 
 /**
  *  This function generates a random string of the provided length by using the SHA-256 hash algorithm.
@@ -186,4 +190,7 @@ export const copyDataDir = async (id: string) => {
       }
     }),
   );
+
+  // Remove any .gitkeep files from the app-data folder at any level
+  await execAsync(`find ${storagePath}/app-data/${id}/data -name .gitkeep -delete`);
 };

--- a/packages/cli/src/executors/app/app.helpers.ts
+++ b/packages/cli/src/executors/app/app.helpers.ts
@@ -192,5 +192,7 @@ export const copyDataDir = async (id: string) => {
   );
 
   // Remove any .gitkeep files from the app-data folder at any level
-  await execAsync(`find ${storagePath}/app-data/${id}/data -name .gitkeep -delete`);
+  if (await pathExists(`${storagePath}/app-data/${id}/data`)) {
+    await execAsync(`find ${storagePath}/app-data/${id}/data -name .gitkeep -delete`).catch(() => {});
+  }
 };

--- a/packages/cli/src/executors/repo/repo.executors.ts
+++ b/packages/cli/src/executors/repo/repo.executors.ts
@@ -76,6 +76,7 @@ export class RepoExecutors {
       this.logger.info(`Pulling repo ${repoUrl} to ${repoPath}`);
 
       await execAsync(`git config --global --add safe.directory ${repoPath}`);
+      await execAsync(`git -C ${repoPath} reset --hard`);
       const { stdout, stderr } = await execAsync(`git -C ${repoPath} pull`);
 
       if (stderr) {

--- a/packages/cli/src/executors/system/system.executors.ts
+++ b/packages/cli/src/executors/system/system.executors.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop */
 import { Queue } from 'bullmq';
 import fs from 'fs';
 import cliProgress from 'cli-progress';
@@ -116,6 +117,14 @@ export class SystemExecutors {
       if (await pathExists(path.join(this.rootFolder, 'apps'))) {
         const apps = await fs.promises.readdir(path.join(this.rootFolder, 'apps'));
         const appExecutor = new AppExecutors();
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const app of apps) {
+          spinner.setMessage(`Stopping ${app}...`);
+          spinner.start();
+          await appExecutor.stopApp(app, {}, true);
+          spinner.done(`${app} stopped`);
+        }
 
         await Promise.all(
           apps.map(async (app) => {

--- a/packages/cli/src/executors/system/system.helpers.ts
+++ b/packages/cli/src/executors/system/system.helpers.ts
@@ -33,6 +33,8 @@ type EnvKeys =
   | 'REDIS_PASSWORD'
   | 'LOCAL_DOMAIN'
   | 'DEMO_MODE'
+  | 'TIPI_GID'
+  | 'TIPI_UID'
   // eslint-disable-next-line @typescript-eslint/ban-types
   | (string & {});
 
@@ -176,6 +178,13 @@ export const generateSystemEnvFile = async () => {
   envMap.set('DEMO_MODE', String(data.demoMode || 'false'));
   envMap.set('LOCAL_DOMAIN', data.localDomain || 'tipi.lan');
   envMap.set('NODE_ENV', 'production');
+
+  const currentUserGroup = process.getgid ? String(process.getgid()) : '1000';
+  const currentUserId = process.getuid ? String(process.getuid()) : '1000';
+  const { stdout: tipiGroupId } = await execAsync('getent group tipi | cut -d: -f3');
+
+  envMap.set('TIPI_GID', tipiGroupId.trim() || currentUserGroup);
+  envMap.set('TIPI_UID', currentUserId);
 
   await fs.promises.writeFile(envFilePath, envMapToString(envMap));
 

--- a/packages/cli/src/services/watcher/watcher.ts
+++ b/packages/cli/src/services/watcher/watcher.ts
@@ -84,7 +84,11 @@ const killOtherWorkers = async () => {
     }
 
     console.log(`Killing worker with pid ${pid}`);
-    process.kill(Number(pid));
+    try {
+      process.kill(Number(pid));
+    } catch (e) {
+      console.error(`Error killing worker with pid ${pid}: ${e}`);
+    }
   });
 };
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -188,11 +188,8 @@ chmod +x ./runtipi-cli
 # Check if user is in docker group
 if [ "$(id -u)" -ne 0 ]; then
   if ! groups | grep -q docker; then
-    echo ""
-    echo "User is not in docker group. Please make sure your user is allowed to run docker commands and restart the script."
-    echo "See https://docs.docker.com/engine/install/linux-postinstall/ for more information."
-    echo ""
-    exit 1
+    sudo usermod -aG docker "$USER"
+    newgrp docker
   fi
 fi
 

--- a/src/server/common/session.helpers.ts
+++ b/src/server/common/session.helpers.ts
@@ -13,7 +13,7 @@ export const generateSessionId = (prefix: string) => {
 export const setSession = async (sessionId: string, userId: string, req: NextApiRequest, res: NextApiResponse) => {
   const cache = new TipiCache();
 
-  setCookie(COOKIE_NAME, sessionId, { req, res, maxAge: COOKIE_MAX_AGE, httpOnly: true, secure: true, sameSite: false });
+  setCookie(COOKIE_NAME, sessionId, { req, res, maxAge: COOKIE_MAX_AGE, httpOnly: true, secure: false, sameSite: false });
 
   const sessionKey = `session:${sessionId}`;
 


### PR DESCRIPTION
## Purpose
Since we are not running as root anymore, some containers needs to be forced into a user:group couple. This PR introduces a new system to generate a `tipi` group on startup and assign it to the current user aswell as exposing the env variables `TIPI_UID` and `TIPI_GID`