### PR TITLE
fix(install.sh): update fedora docker steps to match official instructions

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -127,7 +127,7 @@ function install_docker() {
     return 0
   elif [[ "${os}" == "fedora" ]]; then
     sudo dnf -y install dnf-plugins-core
-    sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+    sudo dnf-3 config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
     sudo dnf -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
     sudo systemctl start docker
     sudo systemctl enable docker


### PR DESCRIPTION
## What it does:
Closes: #2153
Updates docker steps on fedora to follow the official docker instructions. See: https://docs.docker.com/engine/install/fedora/#set-up-the-repository

## Why it was necessary:

![Screenshot From 2025-05-11 08-40-49](https://github.com/user-attachments/assets/daa1bfa1-1724-4061-b034-955d301c9f15)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the command used for adding the Docker repository on Fedora systems during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->