### PR TITLE
feat: use configured domain as a placeholder in expose

### DIFF
--- a/packages/frontend/src/modules/app/components/install-form/install-form.tsx
+++ b/packages/frontend/src/modules/app/components/install-form/install-form.tsx
@@ -44,7 +44,7 @@ const typeFilter = (field: FormField) => !hiddenTypes.includes(field.type);
 export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit, initialValues, loading, formId }) => {
   const { t } = useTranslation();
   const { userSettings } = useAppContext();
-  const { guestDashboard, localDomain, internalIp } = userSettings;
+  const { guestDashboard, localDomain, internalIp, domain } = userSettings;
 
   const {
     register,
@@ -122,7 +122,7 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
             label={t('APP_INSTALL_FORM_DOMAIN_NAME')}
             error={errors.domain?.message}
             disabled={loading}
-            placeholder={t('APP_INSTALL_FORM_DOMAIN_NAME')}
+            placeholder={domain ? `${info.urn.split(':').join('-')}.${domain}` : `${info.urn.split(':').join('-')}.example.com`}
           />
           <span className="text-muted">{t('APP_INSTALL_FORM_DOMAIN_NAME_HINT')}</span>
         </div>

--- a/packages/frontend/src/modules/app/components/install-form/install-form.tsx
+++ b/packages/frontend/src/modules/app/components/install-form/install-form.tsx
@@ -6,6 +6,8 @@ import { Switch } from '@/components/ui/Switch';
 import { useAppContext } from '@/context/app-context';
 import type { AppInfo, FormField } from '@/types/app.types';
 import type { TranslatableError } from '@/types/error.types';
+import { extractAppUrn } from '@/utils/app-helpers';
+import type { AppUrn } from '@runtipi/common/types';
 import { useMutation } from '@tanstack/react-query';
 import clsx from 'clsx';
 import type React from 'react';
@@ -58,6 +60,8 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
   const watchExposed = watch('exposed', false);
   const watchOpenPort = watch('openPort', true);
   const watchExposedLocal = watch('exposedLocal', false);
+
+  const { appName, appStoreId } = extractAppUrn(info.urn as AppUrn);
 
   useEffect(() => {
     if (info.force_expose) {
@@ -122,7 +126,7 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
             label={t('APP_INSTALL_FORM_DOMAIN_NAME')}
             error={errors.domain?.message}
             disabled={loading}
-            placeholder={domain ? `${info.urn.split(':').join('-')}.${domain}` : `${info.urn.split(':').join('-')}.example.com`}
+            placeholder={domain ? `${appName}-${appStoreId}.${domain}` : `${appName}-${appStoreId}.example.com`}
           />
           <span className="text-muted">{t('APP_INSTALL_FORM_DOMAIN_NAME_HINT')}</span>
         </div>


### PR DESCRIPTION
Closes #425
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
  - The domain input field in the install form now displays a context-specific placeholder, dynamically suggesting a domain based on your user settings or a default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->