### PR TITLE
fix: delete app data dir on uninstall

### DIFF
--- a/packages/backend/src/modules/app-lifecycle/commands/uninstall-app-command.ts
+++ b/packages/backend/src/modules/app-lifecycle/commands/uninstall-app-command.ts
@@ -21,6 +21,7 @@ export class UninstallAppCommand extends AppLifecycleCommand {
       }
 
       await appFilesManager.deleteAppFolder(appUrn);
+      await appFilesManager.deleteAppDataDir(appUrn);
 
       return { success: true, message: `App ${appUrn} uninstalled successfully` };
     } catch (err) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved app uninstallation process to ensure both the app folder and its associated data directory are fully removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->