### PR TITLE
feat: add toggle to show and hide passwords in app install form

### DIFF
--- a/packages/backend/src/modules/i18n/translations/en-US.json
+++ b/packages/backend/src/modules/i18n/translations/en-US.json
@@ -418,5 +418,7 @@
   "APP_INSTALL_FORM_LOCAL_SUBDOMAIN": "Subdomain",
   "APP_INSTALL_FORM_ERROR_LOCAL_SUBDOMAIN_INVALID": "Invalid subdomain",
   "APP_INSTALL_FORM_ERROR_LOCAL_SUBDOMAIN_FORMAT": "Subdomain is not valid (only lowercase letters, numbers and dashes are allowed. Max length 63 characters)",
-  "APP_INSTALL_FORM_RANDOM": "Random"
+  "APP_INSTALL_FORM_RANDOM": "Random",
+  "APP_INSTALL_FORM_SHOW_PASSWORD": "Show password",
+  "APP_INSTALL_FORM_HIDE_PASSWORD": "Hide password"
 }

--- a/packages/backend/src/modules/i18n/translations/en.json
+++ b/packages/backend/src/modules/i18n/translations/en.json
@@ -418,5 +418,7 @@
   "APP_INSTALL_FORM_LOCAL_SUBDOMAIN": "Subdomain",
   "APP_INSTALL_FORM_ERROR_LOCAL_SUBDOMAIN_INVALID": "Invalid subdomain",
   "APP_INSTALL_FORM_ERROR_LOCAL_SUBDOMAIN_FORMAT": "Subdomain is not valid (only lowercase letters, numbers and dashes are allowed. Max length 63 characters)",
-  "APP_INSTALL_FORM_RANDOM": "Random"
+  "APP_INSTALL_FORM_RANDOM": "Random",
+  "APP_INSTALL_FORM_SHOW_PASSWORD": "Show password",
+  "APP_INSTALL_FORM_HIDE_PASSWORD": "Hide password"
 }

--- a/packages/frontend/src/components/ui/Input/InputGroup.tsx
+++ b/packages/frontend/src/components/ui/Input/InputGroup.tsx
@@ -7,10 +7,11 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
   isInvalid?: boolean;
   groupPrefix?: string | React.ReactNode;
   groupSuffix?: string | React.ReactNode;
+  groupClassName?: string;
 }
 
 export const InputGroup = React.forwardRef<HTMLInputElement, IProps>(
-  ({ name, label, error, type = 'text', className, isInvalid, groupPrefix, groupSuffix, ...rest }, ref) => {
+  ({ name, label, error, type = 'text', className, isInvalid, groupPrefix, groupSuffix, groupClassName, ...rest }, ref) => {
     let prefix = groupPrefix;
     if (typeof groupPrefix === 'string') {
       prefix = <span className="input-group-text">{groupPrefix}</span>;
@@ -27,7 +28,7 @@ export const InputGroup = React.forwardRef<HTMLInputElement, IProps>(
             {label}
           </label>
         )}
-        <div className="input-group">
+        <div className={clsx('input-group', groupClassName)}>
           {prefix}
           <input
             suppressHydrationWarning

--- a/packages/frontend/src/components/ui/PasswordInput/PasswordInput.tsx
+++ b/packages/frontend/src/components/ui/PasswordInput/PasswordInput.tsx
@@ -1,0 +1,46 @@
+import { useState, type ComponentProps } from 'react';
+import { InputGroup } from '../Input';
+import { Tooltip } from 'react-tooltip';
+import { Button } from '../Button';
+import { IconEye, IconEyeClosed } from '@tabler/icons-react';
+import { useTranslation } from 'react-i18next';
+
+type Props = ComponentProps<typeof InputGroup> & {};
+
+export const PasswordInput = (props: Props) => {
+  const { ref, key, ...rest } = props;
+  const [passwordVisible, setPasswordVisible] = useState(false);
+
+  const { t } = useTranslation();
+
+  return (
+    <InputGroup
+      key={key}
+      ref={ref}
+      type={passwordVisible ? 'text' : 'password'}
+      groupClassName="input-group-flat"
+      {...rest}
+      groupSuffix={
+        <span className="input-group-text">
+          <Tooltip className="tooltip" anchorSelect=".toggle-password-visibility">
+            {passwordVisible ? t('APP_INSTALL_FORM_HIDE_PASSWORD') : t('APP_INSTALL_FORM_SHOW_PASSWORD')}
+          </Tooltip>
+          <Button
+            size="sm"
+            variant="ghost"
+            color="gray"
+            onClick={() => setPasswordVisible(!passwordVisible)}
+            type="button"
+            className="toggle-password-visibility"
+          >
+            {passwordVisible ? (
+              <IconEyeClosed aria-label={t('APP_INSTALL_FORM_HIDE_PASSWORD')} size={16} />
+            ) : (
+              <IconEye aria-label={t('APP_INSTALL_FORM_SHOW_PASSWORD')} size={16} />
+            )}
+          </Button>
+        </span>
+      }
+    />
+  );
+};

--- a/packages/frontend/src/modules/app/components/install-form/install-form-field.tsx
+++ b/packages/frontend/src/modules/app/components/install-form/install-form-field.tsx
@@ -1,4 +1,4 @@
-import { Input, InputGroup } from '@/components/ui/Input';
+import { Input } from '@/components/ui/Input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
 import { Switch } from '@/components/ui/Switch';
 import type { FormField } from '@/types/app.types';
@@ -7,8 +7,7 @@ import { type Control, Controller, type UseFormRegister } from 'react-hook-form'
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from 'react-tooltip';
 import type { FormValues } from './install-form';
-import React from 'react';
-import { Button } from '@/components/ui/Button';
+import { PasswordInput } from '@/components/ui/PasswordInput/PasswordInput';
 
 type IProps = {
   field: FormField;
@@ -27,7 +26,6 @@ type IProps = {
 export const InstallFormField = (props: IProps) => {
   const { field, control, register, initialValue, error, loading } = props;
   const { t } = useTranslation();
-  const [passwordVisible, setPasswordVisible] = React.useState(false);
 
   const label = (
     <>
@@ -103,24 +101,15 @@ export const InstallFormField = (props: IProps) => {
 
   if (field.type === 'password') {
     return (
-      <InputGroup
+      <PasswordInput
         key={field.env_variable}
         {...register(field.env_variable)}
         label={label}
         error={error}
         disabled={loading}
-        type={passwordVisible ? 'text' : 'password'}
         className="mb-3"
-        groupClassName="input-group-flat"
         placeholder={field.placeholder || field.label}
         defaultValue={field.default as string}
-        groupSuffix={
-          <span className="input-group-text">
-            <Button size="sm" variant="ghost" onClick={() => setPasswordVisible(!passwordVisible)} type="button">
-              {passwordVisible ? t('APP_INSTALL_FORM_HIDE_PASSWORD') : t('APP_INSTALL_FORM_SHOW_PASSWORD')}
-            </Button>
-          </span>
-        }
       />
     );
   }

--- a/packages/frontend/src/modules/app/components/install-form/install-form-field.tsx
+++ b/packages/frontend/src/modules/app/components/install-form/install-form-field.tsx
@@ -1,4 +1,4 @@
-import { Input } from '@/components/ui/Input';
+import { Input, InputGroup } from '@/components/ui/Input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
 import { Switch } from '@/components/ui/Switch';
 import type { FormField } from '@/types/app.types';
@@ -7,6 +7,8 @@ import { type Control, Controller, type UseFormRegister } from 'react-hook-form'
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from 'react-tooltip';
 import type { FormValues } from './install-form';
+import React from 'react';
+import { Button } from '@/components/ui/Button';
 
 type IProps = {
   field: FormField;
@@ -25,6 +27,7 @@ type IProps = {
 export const InstallFormField = (props: IProps) => {
   const { field, control, register, initialValue, error, loading } = props;
   const { t } = useTranslation();
+  const [passwordVisible, setPasswordVisible] = React.useState(false);
 
   const label = (
     <>
@@ -96,6 +99,30 @@ export const InstallFormField = (props: IProps) => {
     default:
       type = 'text' as const;
       break;
+  }
+
+  if (field.type === 'password') {
+    return (
+      <InputGroup
+        key={field.env_variable}
+        {...register(field.env_variable)}
+        label={label}
+        error={error}
+        disabled={loading}
+        type={passwordVisible ? 'text' : 'password'}
+        className="mb-3"
+        groupClassName="input-group-flat"
+        placeholder={field.placeholder || field.label}
+        defaultValue={field.default as string}
+        groupSuffix={
+          <span className="input-group-text">
+            <Button size="sm" variant="ghost" onClick={() => setPasswordVisible(!passwordVisible)} type="button">
+              {passwordVisible ? t('APP_INSTALL_FORM_HIDE_PASSWORD') : t('APP_INSTALL_FORM_SHOW_PASSWORD')}
+            </Button>
+          </span>
+        }
+      />
+    );
   }
 
   return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a password visibility toggle to password fields in the app installation form, allowing users to show or hide their password input.
* **Enhancements**
  * Improved input group components to support custom styling through an additional class name option.
* **Localization**
  * Added new English translations for "Show password" and "Hide password" in the app installation form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->