### PR TITLE
fix: localize user-config editor

### DIFF
--- a/packages/backend/src/modules/i18n/translations/en-US.json
+++ b/packages/backend/src/modules/i18n/translations/en-US.json
@@ -420,5 +420,7 @@
   "APP_INSTALL_FORM_ERROR_LOCAL_SUBDOMAIN_FORMAT": "Subdomain is not valid (only lowercase letters, numbers and dashes are allowed. Max length 63 characters)",
   "APP_INSTALL_FORM_RANDOM": "Random",
   "APP_INSTALL_FORM_SHOW_PASSWORD": "Show password",
-  "APP_INSTALL_FORM_HIDE_PASSWORD": "Hide password"
+  "APP_INSTALL_FORM_HIDE_PASSWORD": "Hide password",
+  "SAVE": "Save",
+  "USER_CONFIG_DOCKER_MERGE_DESCRIPTION": "This is a <a>docker merge</a> override file. It will be merged with the base <code>docker-compose</code> file of the app. You can find the base file in the <code>apps</code> folder."
 }

--- a/packages/backend/src/modules/i18n/translations/en.json
+++ b/packages/backend/src/modules/i18n/translations/en.json
@@ -420,5 +420,7 @@
   "APP_INSTALL_FORM_ERROR_LOCAL_SUBDOMAIN_FORMAT": "Subdomain is not valid (only lowercase letters, numbers and dashes are allowed. Max length 63 characters)",
   "APP_INSTALL_FORM_RANDOM": "Random",
   "APP_INSTALL_FORM_SHOW_PASSWORD": "Show password",
-  "APP_INSTALL_FORM_HIDE_PASSWORD": "Hide password"
+  "APP_INSTALL_FORM_HIDE_PASSWORD": "Hide password",
+  "SAVE": "Save",
+  "USER_CONFIG_DOCKER_MERGE_DESCRIPTION": "This is a <a>docker merge</a> override file. It will be merged with the base <code>docker-compose</code> file of the app. You can find the base file in the <code>apps</code> folder."
 }

--- a/packages/frontend/src/modules/app/containers/app-user-config/app-user-config.tsx
+++ b/packages/frontend/src/modules/app/containers/app-user-config/app-user-config.tsx
@@ -9,7 +9,7 @@ import { Alert, AlertDescription, AlertHeading, AlertIcon } from '@/components/u
 import type { AppInfo } from '@/types/app.types';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import {
   disableUserConfigMutation,
   enableUserConfigMutation,
@@ -109,18 +109,19 @@ export const AppUserConfigEditors = ({ info, initialAppEnv, initialDockerCompose
             <TabsTrigger value="app-env">app.env</TabsTrigger>
           </TabsList>
           <TabsContent value="docker-compose">
-            <CodeMirror value={dockerCompose} height="400px" extensions={[yaml()]} onChange={(value) => setDockerCompose(value)} theme={copilot} />
-            <div className="mt-2">
-              This is a{' '}
-              <a target="_blank" rel="noopener" href="https://docs.docker.com/reference/compose-file/merge/">
-                docker merge
-              </a>{' '}
-              override file. It will be merged with the base <code>docker-compose</code> file of the app. You can find the base file in the{' '}
-              <code>apps</code> folder
-            </div>
+            <CodeMirror readOnly={!isEnabled} value={dockerCompose} height="400px" extensions={[yaml()]} onChange={(value) => setDockerCompose(value)} theme={copilot} />
+            <Trans
+              t={t}
+              i18nKey="USER_CONFIG_DOCKER_MERGE_DESCRIPTION"
+              components={{
+                a: <a target="_blank" rel="noopener" href="https://docs.docker.com/reference/compose-file/merge/" />,
+                code: <code />,
+              }}
+              className='mt-2'
+            />
           </TabsContent>
           <TabsContent value="app-env">
-            <CodeMirror value={appEnv} height="400px" onChange={(value) => setAppEnv(value)} theme={copilot} />
+            <CodeMirror readOnly={!isEnabled} value={appEnv} height="400px" onChange={(value) => setAppEnv(value)} theme={copilot} />
           </TabsContent>
         </Tabs>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new translations for "Save" and a descriptive message for Docker merge overrides.
  * The explanatory text for Docker merge overrides is now localized and supports embedded links and code formatting.

* **Enhancements**
  * The code editors for Docker and environment configuration now become read-only when editing is disabled, improving user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->