### PR TITLE
feat: add dns option in dynamic compose

### DIFF
--- a/packages/backend/src/modules/docker/builders/compose.builder.ts
+++ b/packages/backend/src/modules/docker/builders/compose.builder.ts
@@ -101,6 +101,7 @@ export class DockerComposeBuilder {
       .setStopGracePeriod(params.stopGracePeriod)
       .setStdinOpen(params.stdinOpen)
       .setSysctls(params.sysctls)
+      .setDNS(params.dns)
       .setNetwork(`${appName}_${appStoreId}_network`);
 
     if (params.isMain || params.addToMainNetwork) {

--- a/packages/backend/src/modules/docker/builders/service.builder.ts
+++ b/packages/backend/src/modules/docker/builders/service.builder.ts
@@ -90,6 +90,7 @@ export interface BuilderService {
   stopGracePeriod?: string;
   stdinOpen?: boolean;
   sysctls?: Record<string, number>;
+  dns?: string | string[];
 }
 
 export type BuiltService = ReturnType<typeof ServiceBuilder.prototype.build>;
@@ -494,6 +495,11 @@ export class ServiceBuilder {
     return this;
   }
 
+  setDNS(dns?: string | string[]) {
+    this.service.dns = dns;
+    return this;
+  }
+
   /*
    * Search through the labels and replace any {{ RUNTIPI_APP_ID }} or {{RUNTIPI_APP_ID}} with the appId.
    * @param {string} appId The appId to replace the variables with.
@@ -574,6 +580,7 @@ export class ServiceBuilder {
       stop_grace_period: this.service.stopGracePeriod,
       stdin_open: this.service.stdinOpen,
       sysctls: this.service.sysctls,
+      dns: this.service.dns,
     };
 
     // Delete any undefined properties

--- a/packages/common/src/schemas/dynamic-compose.ts
+++ b/packages/common/src/schemas/dynamic-compose.ts
@@ -124,6 +124,7 @@ export const serviceSchema = z.object({
   stopGracePeriod: z.string().optional(),
   stdinOpen: z.boolean().optional(),
   extraLabels: z.record(z.string().or(z.boolean())).optional(),
+  dns: z.string().optional().or(z.array(z.string()).optional()),
 });
 
 export const dynamicComposeSchema = z.object({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying DNS settings when configuring Docker services. Users can now define DNS as either a single value or an array within service configurations.
  
* **Improvements**
  * Enhanced validation to accept DNS configuration in multiple formats for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->