### PR TITLE
refactor(app-actions): move secondary buttons in dropdown menu

### DIFF
--- a/packages/frontend/src/components/ui/DropdownMenu/DropdownMenu.tsx
+++ b/packages/frontend/src/components/ui/DropdownMenu/DropdownMenu.tsx
@@ -33,14 +33,16 @@ DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayNam
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+>(({ className, sideOffset = 4, children, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
       className={clsx('dropdown-menu d-block position-relative', className)}
       {...props}
-    />
+    >
+      {children}
+    </DropdownMenuPrimitive.Content>
   </DropdownMenuPrimitive.Portal>
 ));
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
@@ -65,4 +67,9 @@ const DropdownMenuLabel = React.forwardRef<
 ));
 DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
 
-export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuGroup };
+const DrowdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => <DropdownMenuPrimitive.Separator ref={ref} className={clsx('dropdown-divider', className)} {...props} />);
+
+export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuGroup, DrowdownMenuSeparator };

--- a/packages/frontend/src/components/ui/DropdownMenu/DropdownMenu.tsx
+++ b/packages/frontend/src/components/ui/DropdownMenu/DropdownMenu.tsx
@@ -67,9 +67,9 @@ const DropdownMenuLabel = React.forwardRef<
 ));
 DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
 
-const DrowdownMenuSeparator = React.forwardRef<
+const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
 >(({ className, ...props }, ref) => <DropdownMenuPrimitive.Separator ref={ref} className={clsx('dropdown-divider', className)} {...props} />);
 
-export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuGroup, DrowdownMenuSeparator };
+export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuGroup, DropdownMenuSeparator };

--- a/packages/frontend/src/modules/app/components/app-status/app-status.tsx
+++ b/packages/frontend/src/modules/app/components/app-status/app-status.tsx
@@ -11,7 +11,6 @@ export const AppStatus: React.FC<{ lite?: boolean; status: AppStatusType }> = ({
 
   const classes = clsx('status-dot status-gray', {
     'status-dot-animated status-green': status === 'running',
-    'status-red': status === 'stopped',
   });
 
   if (status === 'missing') return null;

--- a/packages/frontend/src/modules/app/components/app-tile/app-tile.tsx
+++ b/packages/frontend/src/modules/app/components/app-tile/app-tile.tsx
@@ -1,7 +1,7 @@
 import { AppLogo } from '@/components/app-logo/app-logo';
 import { limitText } from '@/lib/helpers/text-helpers';
 import type { AppInfo, AppStatus as AppStatusType } from '@/types/app.types';
-import { IconAlertCircle, IconDownload, IconRotateClockwise } from '@tabler/icons-react';
+import { IconAlertCircle, IconRotateClockwise } from '@tabler/icons-react';
 import type React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from 'react-tooltip';
@@ -41,9 +41,7 @@ export const AppTile: React.FC<{
             <Tooltip className="tooltip" anchorSelect=".updateAvailable">
               {t('MY_APPS_UPDATE_AVAILABLE')}
             </Tooltip>
-            <div className="updateAvailable ribbon bg-green ribbon-top">
-              <IconDownload size={20} />
-            </div>
+            <span className="updateAvailable badge badge-dot bg-red badge-notification" />
           </>
         )}
         {pendingRestart && (

--- a/packages/frontend/src/modules/app/components/dialogs/update-settings-dialog/update-settings-dialog.tsx
+++ b/packages/frontend/src/modules/app/components/dialogs/update-settings-dialog/update-settings-dialog.tsx
@@ -16,11 +16,10 @@ interface IProps {
   config: Record<string, unknown>;
   isOpen: boolean;
   onClose: () => void;
-  onReset: () => void;
   status?: AppStatus;
 }
 
-export const UpdateSettingsDialog: React.FC<IProps> = ({ info, config, isOpen, onClose, onReset, status }) => {
+export const UpdateSettingsDialog: React.FC<IProps> = ({ info, config, isOpen, onClose, status }) => {
   const { t } = useTranslation();
   const formId = useId();
 
@@ -63,7 +62,7 @@ export const UpdateSettingsDialog: React.FC<IProps> = ({ info, config, isOpen, o
           </DialogDescription>
         </ScrollArea>
         <DialogFooter>
-          <InstallFormButtons loading={updateConfig.isPending} isEdit onReset={onReset} status={status} formId={formId} />
+          <InstallFormButtons loading={updateConfig.isPending} isEdit status={status} formId={formId} />
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/packages/frontend/src/modules/app/components/dialogs/update-settings-dialog/update-settings-dialog.tsx
+++ b/packages/frontend/src/modules/app/components/dialogs/update-settings-dialog/update-settings-dialog.tsx
@@ -19,7 +19,7 @@ interface IProps {
   status?: AppStatus;
 }
 
-export const UpdateSettingsDialog: React.FC<IProps> = ({ info, config, isOpen, onClose, status }) => {
+export const UpdateSettingsDialog: React.FC<IProps> = ({ info, config, isOpen, onClose }) => {
   const { t } = useTranslation();
   const formId = useId();
 
@@ -62,7 +62,7 @@ export const UpdateSettingsDialog: React.FC<IProps> = ({ info, config, isOpen, o
           </DialogDescription>
         </ScrollArea>
         <DialogFooter>
-          <InstallFormButtons loading={updateConfig.isPending} isEdit status={status} formId={formId} />
+          <InstallFormButtons loading={updateConfig.isPending} isEdit formId={formId} />
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/packages/frontend/src/modules/app/components/install-form-buttons/install-form-buttons.tsx
+++ b/packages/frontend/src/modules/app/components/install-form-buttons/install-form-buttons.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@/components/ui/Button';
-import type { AppStatus } from '@/types/app.types';
 import type React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -7,7 +6,6 @@ interface IProps {
   isEdit?: boolean;
   loading?: boolean;
   formId: string;
-  status?: AppStatus;
 }
 
 export const InstallFormButtons: React.FC<IProps> = ({ isEdit, loading, formId }) => {

--- a/packages/frontend/src/modules/app/components/install-form-buttons/install-form-buttons.tsx
+++ b/packages/frontend/src/modules/app/components/install-form-buttons/install-form-buttons.tsx
@@ -6,29 +6,16 @@ import { useTranslation } from 'react-i18next';
 interface IProps {
   isEdit?: boolean;
   loading?: boolean;
-  onReset?: () => void;
   formId: string;
   status?: AppStatus;
 }
 
-export const InstallFormButtons: React.FC<IProps> = ({ isEdit, loading, onReset, formId, status }) => {
+export const InstallFormButtons: React.FC<IProps> = ({ isEdit, loading, formId }) => {
   const { t } = useTranslation();
 
-  const onClickReset = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    e.preventDefault();
-    if (onReset) onReset();
-  };
-
   return (
-    <>
-      <Button loading={loading} type="submit" intent="success" form={formId}>
-        {isEdit ? t('APP_INSTALL_FORM_SUBMIT_UPDATE') : t('APP_INSTALL_FORM_SUBMIT_INSTALL')}
-      </Button>
-      {isEdit && onReset && (
-        <Button loading={status === 'stopping'} onClick={onClickReset} intent="danger" className="ms-2">
-          {t('APP_INSTALL_FORM_RESET')}
-        </Button>
-      )}
-    </>
+    <Button loading={loading} type="submit" intent="success" form={formId}>
+      {isEdit ? t('APP_INSTALL_FORM_SUBMIT_UPDATE') : t('APP_INSTALL_FORM_SUBMIT_INSTALL')}
+    </Button>
   );
 };

--- a/packages/frontend/src/modules/app/containers/app-actions/app-actions.tsx
+++ b/packages/frontend/src/modules/app/containers/app-actions/app-actions.tsx
@@ -32,8 +32,8 @@ import { UninstallDialog } from '../../components/dialogs/uninstall-dialog/unins
 import { UpdateDialog } from '../../components/dialogs/update-dialog/update-dialog';
 import { UpdateSettingsDialog } from '../../components/dialogs/update-settings-dialog/update-settings-dialog';
 import { useAppStatus } from '../../helpers/use-app-status';
-import { DrowdownMenuSeparator } from '@/components/ui/DropdownMenu/DropdownMenu';
 import { Tooltip } from 'react-tooltip';
+import { DropdownMenuSeparator } from '@/components/ui/DropdownMenu/DropdownMenu';
 
 interface IProps {
   app?: AppDetails | null;
@@ -101,26 +101,26 @@ export const AppActions = ({ app, info, localDomain, metadata, sslPort }: IProps
   const LoadingButton = <ActionButton key="loading" loading intent="success" title={t('APP_ACTION_LOADING')} />;
 
   const RemoveListItem = (
-    <DropdownMenuItem onClick={uninstallDisclosure.open}>
+    <DropdownMenuItem onClick={uninstallDisclosure.open} key="remove" className="text-danger">
       <IconTrash className="me-2" size={16} />
       {t('APP_ACTION_REMOVE')}
     </DropdownMenuItem>
   );
   const SettingsListItem = (
-    <DropdownMenuItem onClick={updateSettingsDisclosure.open}>
+    <DropdownMenuItem onClick={updateSettingsDisclosure.open} key="settings">
       <IconSettings className="me-2" size={16} />
       {t('APP_ACTION_SETTINGS')}
     </DropdownMenuItem>
   );
   const RestartListItem = (
-    <DropdownMenuItem onClick={restartDisclosure.open}>
+    <DropdownMenuItem onClick={restartDisclosure.open} key="restart">
       <IconRotateClockwise className="me-2" size={16} />
       {t('APP_ACTION_RESTART')}
       {app?.pendingRestart && <span className="badge badge-warning ms-2">{t('MY_APPS_PENDING_RESTART')}</span>}
     </DropdownMenuItem>
   );
   const UpdateListItem = (
-    <DropdownMenuItem onClick={updateDisclosure.open}>
+    <DropdownMenuItem onClick={updateDisclosure.open} key="update">
       <IconDownload className="me-2" size={16} />
       <div>
         {t('APP_ACTION_UPDATE')}
@@ -129,13 +129,13 @@ export const AppActions = ({ app, info, localDomain, metadata, sslPort }: IProps
     </DropdownMenuItem>
   );
   const CancelListItem = (
-    <DropdownMenuItem onClick={stopDisclosure.open}>
+    <DropdownMenuItem onClick={stopDisclosure.open} key="cancel">
       <IconPlayerPause className="me-2" size={16} />
       {t('APP_ACTION_CANCEL')}
     </DropdownMenuItem>
   );
   const ResetListItem = (
-    <DropdownMenuItem onClick={resetAppDisclosure.open}>
+    <DropdownMenuItem onClick={resetAppDisclosure.open} key="reset" className="text-danger">
       <IconEraser className="me-2" size={16} />
       {t('APP_INSTALL_FORM_RESET')}
     </DropdownMenuItem>
@@ -285,21 +285,9 @@ export const AppActions = ({ app, info, localDomain, metadata, sslPort }: IProps
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
-              <DropdownMenuGroup>
-                {listItems.map((item) => (
-                  <DropdownMenuItem key={item.key} onClick={() => item.props.onClick?.()}>
-                    {item.props.children}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuGroup>
-              {listItemsDestructive.length > 0 ? <DrowdownMenuSeparator /> : null}
-              <DropdownMenuGroup>
-                {listItemsDestructive.map((item) => (
-                  <DropdownMenuItem key={item.key} onClick={() => item.props.onClick?.()} className="text-danger">
-                    {item.props.children}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuGroup>
+              <DropdownMenuGroup>{listItems}</DropdownMenuGroup>
+              {listItemsDestructive.length > 0 ? <DropdownMenuSeparator /> : null}
+              <DropdownMenuGroup>{listItemsDestructive}</DropdownMenuGroup>
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/packages/frontend/src/modules/app/containers/app-actions/app-actions.tsx
+++ b/packages/frontend/src/modules/app/containers/app-actions/app-actions.tsx
@@ -14,14 +14,7 @@ import {
 import type React from 'react';
 import { createElement } from 'react';
 import { Button, type ButtonProps } from '@/components/ui/Button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-} from '@/components/ui/DropdownMenu';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/DropdownMenu';
 import { useDisclosure } from '@/lib/hooks/use-disclosure';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -40,6 +33,7 @@ import { UpdateDialog } from '../../components/dialogs/update-dialog/update-dial
 import { UpdateSettingsDialog } from '../../components/dialogs/update-settings-dialog/update-settings-dialog';
 import { useAppStatus } from '../../helpers/use-app-status';
 import { DrowdownMenuSeparator } from '@/components/ui/DropdownMenu/DropdownMenu';
+import { Tooltip } from 'react-tooltip';
 
 interface IProps {
   app?: AppDetails | null;
@@ -161,7 +155,6 @@ export const AppActions = ({ app, info, localDomain, metadata, sslPort }: IProps
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        <DropdownMenuLabel>{t('APP_DETAILS_CHOOSE_OPEN_METHOD')}</DropdownMenuLabel>
         <DropdownMenuGroup>
           {app?.exposed && app.domain && (
             <DropdownMenuItem onClick={() => handleOpen('domain')}>
@@ -283,8 +276,12 @@ export const AppActions = ({ app, info, localDomain, metadata, sslPort }: IProps
         {listItems.length > 0 && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button className="">
+              <Button>
                 <IconDots size={14} />
+                <Tooltip className="tooltip" anchorSelect=".updateAvailable">
+                  {t('MY_APPS_UPDATE_AVAILABLE')}
+                </Tooltip>
+                {updateAvailable && <span className="updateAvailable badge badge-dot bg-red badge-notification" />}
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>

--- a/packages/frontend/src/modules/app/containers/app-actions/app-actions.tsx
+++ b/packages/frontend/src/modules/app/containers/app-actions/app-actions.tsx
@@ -1,5 +1,7 @@
 import {
+  IconDots,
   IconDownload,
+  IconEraser,
   IconExternalLink,
   IconLock,
   IconLockOff,
@@ -8,11 +10,9 @@ import {
   IconRotateClockwise,
   IconSettings,
   IconTrash,
-  IconX,
 } from '@tabler/icons-react';
 import type React from 'react';
-import { Fragment } from 'react';
-
+import { createElement } from 'react';
 import { Button, type ButtonProps } from '@/components/ui/Button';
 import {
   DropdownMenu,
@@ -31,7 +31,6 @@ import type { AppDetails, AppInfo, AppMetadata } from '@/types/app.types';
 import type { TranslatableError } from '@/types/error.types';
 import { useMutation } from '@tanstack/react-query';
 import clsx from 'clsx';
-import { Tooltip } from 'react-tooltip';
 import { InstallDialog } from '../../components/dialogs/install-dialog/install-dialog';
 import { ResetDialog } from '../../components/dialogs/reset-dialog/reset-dialog';
 import { RestartDialog } from '../../components/dialogs/restart-dialog/restart-dialog';
@@ -40,6 +39,7 @@ import { UninstallDialog } from '../../components/dialogs/uninstall-dialog/unins
 import { UpdateDialog } from '../../components/dialogs/update-dialog/update-dialog';
 import { UpdateSettingsDialog } from '../../components/dialogs/update-settings-dialog/update-settings-dialog';
 import { useAppStatus } from '../../helpers/use-app-status';
+import { DrowdownMenuSeparator } from '@/components/ui/DropdownMenu/DropdownMenu';
 
 interface IProps {
   app?: AppDetails | null;
@@ -85,8 +85,6 @@ export const AppActions = ({ app, info, localDomain, metadata, sslPort }: IProps
 
   const appLocalDomain = `${metadata.localSubdomain}.${localDomain}${sslPort !== 443 ? `:${sslPort}` : ''}`;
 
-  const buttons: React.JSX.Element[] = [];
-
   const startMutation = useMutation({
     ...startAppMutation(),
     onError: (e: TranslatableError) => {
@@ -106,37 +104,53 @@ export const AppActions = ({ app, info, localDomain, metadata, sslPort }: IProps
       intent="success"
     />
   );
-  const RemoveButton = (
-    <ActionButton key="remove" IconComponent={IconTrash} onClick={uninstallDisclosure.open} title={t('APP_ACTION_REMOVE')} intent="danger" />
-  );
-  const SettingsButton = (
-    <ActionButton key="settings" IconComponent={IconSettings} onClick={updateSettingsDisclosure.open} title={t('APP_ACTION_SETTINGS')} />
-  );
-  const StopButton = (
-    <ActionButton key="stop" IconComponent={IconPlayerPause} onClick={stopDisclosure.open} title={t('APP_ACTION_STOP')} intent="danger" />
-  );
-  const restartButton = (
-    <Fragment key="restart">
-      {app?.pendingRestart && (
-        <Tooltip className="tooltip" anchorSelect=".pendingRestart">
-          {t('MY_APPS_PENDING_RESTART')}
-        </Tooltip>
-      )}
-      <ActionButton
-        IconComponent={IconRotateClockwise}
-        onClick={restartDisclosure.open}
-        title={t('APP_ACTION_RESTART')}
-        className="pendingRestart"
-        intent={app?.pendingRestart ? 'warning' : 'default'}
-      />
-    </Fragment>
-  );
   const LoadingButton = <ActionButton key="loading" loading intent="success" title={t('APP_ACTION_LOADING')} />;
-  const CancelButton = <ActionButton key="cancel" IconComponent={IconX} onClick={stopDisclosure.open} title={t('APP_ACTION_CANCEL')} />;
-  const InstallButton = <ActionButton key="install" onClick={installDisclosure.open} title={t('APP_ACTION_INSTALL')} intent="success" />;
-  const UpdateButton = (
-    <ActionButton key="update" IconComponent={IconDownload} onClick={updateDisclosure.open} title={t('APP_ACTION_UPDATE')} intent="success" />
+
+  const RemoveListItem = (
+    <DropdownMenuItem onClick={uninstallDisclosure.open}>
+      <IconTrash className="me-2" size={16} />
+      {t('APP_ACTION_REMOVE')}
+    </DropdownMenuItem>
   );
+  const SettingsListItem = (
+    <DropdownMenuItem onClick={updateSettingsDisclosure.open}>
+      <IconSettings className="me-2" size={16} />
+      {t('APP_ACTION_SETTINGS')}
+    </DropdownMenuItem>
+  );
+  const RestartListItem = (
+    <DropdownMenuItem onClick={restartDisclosure.open}>
+      <IconRotateClockwise className="me-2" size={16} />
+      {t('APP_ACTION_RESTART')}
+      {app?.pendingRestart && <span className="badge badge-warning ms-2">{t('MY_APPS_PENDING_RESTART')}</span>}
+    </DropdownMenuItem>
+  );
+  const UpdateListItem = (
+    <DropdownMenuItem onClick={updateDisclosure.open}>
+      <IconDownload className="me-2" size={16} />
+      <div>
+        {t('APP_ACTION_UPDATE')}
+        <span className="ms-2 badge bg-red" />
+      </div>
+    </DropdownMenuItem>
+  );
+  const CancelListItem = (
+    <DropdownMenuItem onClick={stopDisclosure.open}>
+      <IconPlayerPause className="me-2" size={16} />
+      {t('APP_ACTION_CANCEL')}
+    </DropdownMenuItem>
+  );
+  const ResetListItem = (
+    <DropdownMenuItem onClick={resetAppDisclosure.open}>
+      <IconEraser className="me-2" size={16} />
+      {t('APP_INSTALL_FORM_RESET')}
+    </DropdownMenuItem>
+  );
+
+  const StopButton = (
+    <ActionButton key="stop" IconComponent={IconPlayerPause} onClick={stopDisclosure.open} title={t('APP_ACTION_STOP')} intent="default" />
+  );
+  const InstallButton = <ActionButton key="install" onClick={installDisclosure.open} title={t('APP_ACTION_INSTALL')} intent="success" />;
 
   const OpenButton = (
     <DropdownMenu>
@@ -173,20 +187,33 @@ export const AppActions = ({ app, info, localDomain, metadata, sslPort }: IProps
     </DropdownMenu>
   );
 
+  const buttons: React.JSX.Element[] = [];
+  const listItems: React.JSX.Element[] = [];
+  const listItemsDestructive: React.JSX.Element[] = [];
+
   switch (app?.status ?? 'missing') {
     case 'stopped':
-      buttons.push(StartButton, RemoveButton, SettingsButton);
+      buttons.push(StartButton);
+      listItems.push(SettingsListItem);
+      listItemsDestructive.push(ResetListItem);
+      listItemsDestructive.push(RemoveListItem);
       if (updateAvailable) {
-        buttons.push(UpdateButton);
+        listItems.push(UpdateListItem);
       }
       break;
     case 'running':
-      buttons.push(StopButton, restartButton, SettingsButton);
+      buttons.push(StopButton);
+      listItems.push(SettingsListItem);
+      listItems.push(RestartListItem);
+      listItemsDestructive.push(ResetListItem);
+      listItemsDestructive.push(RemoveListItem);
+
       if (!info.no_gui && (app?.exposedLocal || app?.openPort || app?.exposed)) {
         buttons.push(OpenButton);
       }
+
       if (updateAvailable) {
-        buttons.push(UpdateButton);
+        listItems.push(UpdateListItem);
       }
       break;
     case 'installing':
@@ -196,13 +223,10 @@ export const AppActions = ({ app, info, localDomain, metadata, sslPort }: IProps
     case 'restarting':
     case 'updating':
     case 'resetting':
-      buttons.push(LoadingButton, CancelButton);
-      break;
     case 'backing_up':
-      buttons.push(LoadingButton, CancelButton);
-      break;
     case 'restoring':
-      buttons.push(LoadingButton, CancelButton);
+      buttons.push(LoadingButton);
+      listItems.push(CancelListItem);
       break;
     case 'missing':
       buttons.push(InstallButton);
@@ -233,14 +257,6 @@ export const AppActions = ({ app, info, localDomain, metadata, sslPort }: IProps
     window.open(url, '_blank', 'noreferrer');
   };
 
-  const openResetAppModal = () => {
-    updateSettingsDisclosure.close();
-
-    setTimeout(() => {
-      resetAppDisclosure.open();
-    }, 300);
-  };
-
   const newVersion = [metadata?.latestDockerVersion ? `${metadata?.latestDockerVersion}` : '', `(${String(metadata?.latestVersion)})`].join(' ');
 
   return (
@@ -256,12 +272,40 @@ export const AppActions = ({ app, info, localDomain, metadata, sslPort }: IProps
         onClose={updateSettingsDisclosure.close}
         info={info}
         config={app?.config ?? {}}
-        onReset={openResetAppModal}
       />
       <div className="mt-1 btn-list d-flex">
-        {buttons.map((button) => (
-          <Fragment key={button.key}>{button}</Fragment>
-        ))}
+        {buttons.map((button) => {
+          return createElement(button.type, {
+            ...button.props,
+            key: button.key,
+          });
+        })}
+        {listItems.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button className="">
+                <IconDots size={14} />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuGroup>
+                {listItems.map((item) => (
+                  <DropdownMenuItem key={item.key} onClick={() => item.props.onClick?.()}>
+                    {item.props.children}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuGroup>
+              {listItemsDestructive.length > 0 ? <DrowdownMenuSeparator /> : null}
+              <DropdownMenuGroup>
+                {listItemsDestructive.map((item) => (
+                  <DropdownMenuItem key={item.key} onClick={() => item.props.onClick?.()} className="text-danger">
+                    {item.props.children}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
     </>
   );

--- a/packages/frontend/src/modules/dashboard/pages/guest-dashboard.tsx
+++ b/packages/frontend/src/modules/dashboard/pages/guest-dashboard.tsx
@@ -2,34 +2,16 @@ import type { GuestAppsDto } from '@/api-client';
 import { getGuestAppsOptions, getGuestLinksOptions } from '@/api-client/@tanstack/react-query.gen';
 import { GuestHeader } from '@/components/header/guest-header';
 import { PageTitle } from '@/components/page-title/page-title';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-} from '@/components/ui/DropdownMenu';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/DropdownMenu';
 import { AppTile } from '@/modules/app/components/app-tile/app-tile';
 import { IconLock, IconLockOff } from '@tabler/icons-react';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { useTranslation } from 'react-i18next';
 import './guest-dashboard.css';
 import { EmptyPage } from '@/components/empty-page/empty-page';
 import { useUserContext } from '@/context/user-context';
 import { GuestLinkTile } from '../components/guest-link-tile';
 
-const Tile = ({
-  data,
-  localDomain,
-  sslPort,
-}: {
-  data: GuestAppsDto['installed'][number];
-  localDomain: string;
-  sslPort: number;
-}) => {
-  const { t } = useTranslation();
-
+const Tile = ({ data, localDomain, sslPort }: { data: GuestAppsDto['installed'][number]; localDomain: string; sslPort: number }) => {
   const { info, app, metadata } = data;
 
   const hostname = typeof window !== 'undefined' ? window.location.hostname : '';
@@ -65,7 +47,6 @@ const Tile = ({
         </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        <DropdownMenuLabel>{t('APP_DETAILS_CHOOSE_OPEN_METHOD')}</DropdownMenuLabel>
         <DropdownMenuGroup>
           {app.exposed && app.domain && (
             <DropdownMenuItem onClick={() => handleOpen('domain')}>


### PR DESCRIPTION
<img width="427" height="269" alt="image" src="https://github.com/user-attachments/assets/c99d0987-f88f-4dc4-8d06-a542d2986810" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a separator component for dropdown menus to visually group actions.

* **Refactor**
  * Updated app action buttons: primary actions remain as visible buttons, while secondary and destructive actions are now grouped in a dropdown menu for a cleaner interface.
  * Simplified update availability indicator with a red badge dot replacing the previous ribbon icon.
  * Removed translation label from guest dashboard dropdown menus for a streamlined UI.

* **Bug Fixes**
  * Status indicator no longer displays a red dot for stopped status.

* **Chores**
  * Removed reset functionality from settings dialogs and install form buttons for a simplified user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->