### PR TITLE
refactor(frontend): remove forwardRefs

### DIFF
--- a/packages/frontend/src/components/ui/Button/Button.tsx
+++ b/packages/frontend/src/components/ui/Button/Button.tsx
@@ -1,7 +1,7 @@
 import { Slot } from '@radix-ui/react-slot';
 import { type VariantProps, cva } from 'class-variance-authority';
 import clsx from 'clsx';
-import * as React from 'react';
+import type * as React from 'react';
 
 const buttonVariants = cva('btn', {
   variants: {
@@ -67,25 +67,21 @@ const buttonVariants = cva('btn', {
   },
 });
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+export interface ButtonProps extends React.ComponentProps<'button'>, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
   loading?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, intent, asChild = false, disabled, loading, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button';
-    return (
-      <Comp
-        disabled={disabled}
-        style={{ height: size ? 'auto' : '36px' }}
-        className={clsx(buttonVariants({ variant, size, intent, className }), { disabled: disabled || loading, 'btn-loading': loading }, className)}
-        ref={ref}
-        {...props}
-      />
-    );
-  },
-);
-Button.displayName = 'Button';
+const Button = ({ className, variant, size, intent, asChild = false, disabled, loading, ...props }: ButtonProps) => {
+  const Comp = asChild ? Slot : 'button';
+  return (
+    <Comp
+      disabled={disabled}
+      style={{ height: size ? 'auto' : '36px' }}
+      className={clsx(buttonVariants({ variant, size, intent, className }), { disabled: disabled || loading, 'btn-loading': loading }, className)}
+      {...props}
+    />
+  );
+};
 
 export { Button, buttonVariants };

--- a/packages/frontend/src/components/ui/ContextMenu/ContextMenu.tsx
+++ b/packages/frontend/src/components/ui/ContextMenu/ContextMenu.tsx
@@ -3,7 +3,7 @@
 import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
 import { IconCheck, IconChevronRight, IconCircle } from '@tabler/icons-react';
 import clsx from 'clsx';
-import * as React from 'react';
+import type * as React from 'react';
 
 const ContextMenu = ContextMenuPrimitive.Root;
 
@@ -17,91 +17,74 @@ const ContextMenuSub = ContextMenuPrimitive.Sub;
 
 const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
 
-const ContextMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
-    inset?: boolean;
-  }
->(({ className, inset, children, ...props }, ref) => (
-  <ContextMenuPrimitive.SubTrigger ref={ref} className={clsx('', inset && 'ps-2', className)} {...props}>
+const ContextMenuSubTrigger = ({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) => (
+  <ContextMenuPrimitive.SubTrigger className={clsx('', inset && 'ps-2', className)} {...props}>
     {children}
     <IconChevronRight className="" />
   </ContextMenuPrimitive.SubTrigger>
-));
-ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
+);
 
-const ContextMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => <ContextMenuPrimitive.SubContent ref={ref} className={clsx('', className)} {...props} />);
-ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
+const ContextMenuSubContent = ({ className, ...props }: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) => (
+  <ContextMenuPrimitive.SubContent className={clsx('', className)} {...props} />
+);
 
-const ContextMenuContent = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
->(({ className, ...props }, ref) => (
+const ContextMenuContent = ({ className, ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Content>) => (
   <ContextMenuPrimitive.Portal>
-    <ContextMenuPrimitive.Content ref={ref} className={clsx('dropdown-menu dropdown-menu-demo', className)} style={{ display: 'block' }} {...props} />
+    <ContextMenuPrimitive.Content className={clsx('dropdown-menu dropdown-menu-demo', className)} style={{ display: 'block' }} {...props} />
   </ContextMenuPrimitive.Portal>
-));
-ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+);
 
-const ContextMenuItem = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
-  <ContextMenuPrimitive.Item ref={ref} className={clsx('dropdown-item cursor-pointer', inset && 'ps-2', className)} {...props} />
-));
-ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+const ContextMenuItem = ({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+  inset?: boolean;
+}) => <ContextMenuPrimitive.Item className={clsx('dropdown-item cursor-pointer', inset && 'ps-2', className)} {...props} />;
 
-const ContextMenuCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
-  <ContextMenuPrimitive.CheckboxItem ref={ref} className={clsx('', className)} checked={checked} {...props}>
-    <span className="">
+const ContextMenuCheckboxItem = ({ className, children, checked, ...props }: React.ComponentProps<typeof ContextMenuPrimitive.CheckboxItem>) => (
+  <ContextMenuPrimitive.CheckboxItem className={clsx('', className)} checked={checked} {...props}>
+    <span>
       <ContextMenuPrimitive.ItemIndicator>
-        <IconCheck className="" />
+        <IconCheck />
       </ContextMenuPrimitive.ItemIndicator>
     </span>
     {children}
   </ContextMenuPrimitive.CheckboxItem>
-));
-ContextMenuCheckboxItem.displayName = ContextMenuPrimitive.CheckboxItem.displayName;
+);
 
-const ContextMenuRadioItem = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => (
-  <ContextMenuPrimitive.RadioItem ref={ref} className={clsx('', className)} {...props}>
-    <span className="">
+const ContextMenuRadioItem = ({ className, children, ...props }: React.ComponentProps<typeof ContextMenuPrimitive.RadioItem>) => (
+  <ContextMenuPrimitive.RadioItem className={clsx('', className)} {...props}>
+    <span>
       <ContextMenuPrimitive.ItemIndicator>
-        <IconCircle className="" />
+        <IconCircle />
       </ContextMenuPrimitive.ItemIndicator>
     </span>
     {children}
   </ContextMenuPrimitive.RadioItem>
-));
-ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
+);
 
-const ContextMenuLabel = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => <ContextMenuPrimitive.Label ref={ref} className={clsx('', inset && 'ps-2', className)} {...props} />);
-ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName;
+const ContextMenuLabel = ({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
+  inset?: boolean;
+}) => <ContextMenuPrimitive.Label className={clsx('', { 'ps-2': inset }, className)} {...props} />;
 
-const ContextMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
->(({ className, ...props }, ref) => <ContextMenuPrimitive.Separator ref={ref} className={clsx('', className)} {...props} />);
-ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
+const ContextMenuSeparator = ({ className, ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) => (
+  <ContextMenuPrimitive.Separator className={clsx('', className)} {...props} />
+);
 
 const ContextMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
-  return <span className={clsx('', className)} {...props} />;
+  return <span className={className} {...props} />;
 };
 ContextMenuShortcut.displayName = 'ContextMenuShortcut';
 

--- a/packages/frontend/src/components/ui/Dialog/Dialog.tsx
+++ b/packages/frontend/src/components/ui/Dialog/Dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import clsx from 'clsx';
-import * as React from 'react';
+import type * as React from 'react';
 import './Dialog.css';
 
 type Sizes = 'sm' | 'md' | 'lg' | 'xl';
@@ -30,27 +30,21 @@ const DialogPortal = ({ children, ...props }: DialogPrimitive.DialogPortalProps 
 );
 DialogPortal.displayName = DialogPrimitive.Portal.displayName;
 
-const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => <DialogPrimitive.Overlay className={clsx('', className)} {...props} ref={ref} />);
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+const DialogOverlay = ({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) => (
+  <DialogPrimitive.Overlay className={clsx('', className)} {...props} />
+);
 
-const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & ModalProps
->(({ className, children, ...props }, ref) => (
+const DialogContent = ({ className, children, ...props }: React.ComponentProps<typeof DialogPrimitive.Content> & ModalProps) => (
   <DialogPortal type={props.type} size={props.size}>
     <DialogOverlay />
-    <DialogPrimitive.Content ref={ref} className={clsx('modal-content mt-1', className)} {...props}>
+    <DialogPrimitive.Content className={clsx('modal-content mt-1', className)} {...props}>
       {children}
       <DialogPrimitive.Close className="btn-close">
         <span data-testid="modal-close-button" className="btn-close" aria-label="Close" />
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-));
-DialogContent.displayName = DialogPrimitive.Content.displayName;
+);
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div data-testid="modal-header" className={clsx('modal-header', className)} {...props} />
@@ -62,19 +56,14 @@ const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 );
 DialogFooter.displayName = 'DialogFooter';
 
-const DialogTitle = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Title>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>>(
-  ({ className, ...props }, ref) => <DialogPrimitive.Title ref={ref} className={clsx('modal-title', className)} {...props} />,
+const DialogTitle = ({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) => (
+  <DialogPrimitive.Title className={clsx('modal-title', className)} {...props} />
 );
-DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
-const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description ref={ref} asChild {...props}>
+const DialogDescription = ({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) => (
+  <DialogPrimitive.Description asChild {...props}>
     <div className={clsx('modal-body', className)}>{props.children}</div>
   </DialogPrimitive.Description>
-));
-DialogDescription.displayName = DialogPrimitive.Description.displayName;
+);
 
 export { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription };

--- a/packages/frontend/src/components/ui/DropdownMenu/DropdownMenu.tsx
+++ b/packages/frontend/src/components/ui/DropdownMenu/DropdownMenu.tsx
@@ -3,7 +3,7 @@
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { IconChevronRight } from '@tabler/icons-react';
 import clsx from 'clsx';
-import * as React from 'react';
+import type * as React from 'react';
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
@@ -11,65 +11,58 @@ const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 
 const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 
-const DropdownMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean;
-  }
->(({ className, inset, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubTrigger ref={ref} className={clsx('', inset && 'ps-8', className)} {...props}>
+const DropdownMenuSubTrigger = ({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) => (
+  <DropdownMenuPrimitive.SubTrigger className={clsx('', inset && 'ps-8', className)} {...props}>
     {children}
     <IconChevronRight className="" />
   </DropdownMenuPrimitive.SubTrigger>
-));
-DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+);
 
-const DropdownMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => <DropdownMenuPrimitive.SubContent ref={ref} className={clsx('', className)} {...props} />);
-DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
+const DropdownMenuSubContent = ({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) => (
+  <DropdownMenuPrimitive.SubContent className={clsx('', className)} {...props} />
+);
 
-const DropdownMenuContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, children, ...props }, ref) => (
+const DropdownMenuContent = ({ className, sideOffset = 4, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) => (
   <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={clsx('dropdown-menu d-block position-relative', className)}
-      {...props}
-    >
-      {children}
-    </DropdownMenuPrimitive.Content>
+    <DropdownMenuPrimitive.Content sideOffset={sideOffset} className={clsx('dropdown-menu d-block position-relative', className)} {...props} />
   </DropdownMenuPrimitive.Portal>
-));
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+);
 
-const DropdownMenuItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item ref={ref} className={clsx('dropdown-item cursor-pointer', inset && 'ps-1', className)} {...props} />
-));
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+const DropdownMenuItem = ({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+}) => <DropdownMenuPrimitive.Item className={clsx('dropdown-item cursor-pointer', inset && 'ps-1', className)} {...props} />;
 
-const DropdownMenuLabel = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Label ref={ref} className={clsx('dropdown-header', inset && 'pl-8', className)} {...props} />
-));
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+const DropdownMenuLabel = ({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) => <DropdownMenuPrimitive.Label className={clsx('dropdown-header', inset && 'pl-8', className)} {...props} />;
 
-const DropdownMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
->(({ className, ...props }, ref) => <DropdownMenuPrimitive.Separator ref={ref} className={clsx('dropdown-divider', className)} {...props} />);
+const DropdownMenuSeparator = ({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) => (
+  <DropdownMenuPrimitive.Separator className={clsx('dropdown-divider', className)} {...props} />
+);
 
-export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuGroup, DropdownMenuSeparator };
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuSubTrigger,
+  DropdownMenuContent,
+  DropdownMenuSubContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuGroup,
+  DropdownMenuSeparator,
+};

--- a/packages/frontend/src/components/ui/Input/Input.tsx
+++ b/packages/frontend/src/components/ui/Input/Input.tsx
@@ -1,33 +1,33 @@
 import clsx from 'clsx';
-import React from 'react';
+import type React from 'react';
 
 interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
   error?: string;
   label?: string | React.ReactNode;
   isInvalid?: boolean;
   children?: React.ReactNode;
+  ref?: React.Ref<HTMLInputElement>;
 }
 
-export const Input = React.forwardRef<HTMLInputElement, IProps>(
-  ({ name, label, error, type = 'text', className, isInvalid, children, ...rest }, ref) => (
-    <div className={clsx(className)}>
-      {label && (
-        <label htmlFor={name} className="form-label">
-          {label}
-        </label>
-      )}
-      <input
-        suppressHydrationWarning
-        aria-label={name}
-        type={type}
-        name={name}
-        id={name}
-        ref={ref}
-        className={clsx('form-control', { 'is-invalid is-invalid-lite': error || isInvalid })}
-        {...rest}
-      />
-      {children}
-      {error && <div className="invalid-feedback">{error}</div>}
-    </div>
-  ),
+export const Input = ({ name, label, error, type = 'text', className, isInvalid, children, ...rest }: IProps) => (
+  <div className={clsx(className)}>
+    {label && (
+      <label htmlFor={name} className="form-label">
+        {label}
+      </label>
+    )}
+    <input
+      suppressHydrationWarning
+      aria-label={name}
+      type={type}
+      name={name}
+      id={name}
+      className={clsx('form-control', {
+        'is-invalid is-invalid-lite': error || isInvalid,
+      })}
+      {...rest}
+    />
+    {children}
+    {error && <div className="invalid-feedback">{error}</div>}
+  </div>
 );

--- a/packages/frontend/src/components/ui/Input/InputGroup.tsx
+++ b/packages/frontend/src/components/ui/Input/InputGroup.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React from 'react';
+import type * as React from 'react';
 
 interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
   error?: string;
@@ -8,42 +8,51 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
   groupPrefix?: string | React.ReactNode;
   groupSuffix?: string | React.ReactNode;
   groupClassName?: string;
+  ref?: React.Ref<HTMLInputElement>;
 }
 
-export const InputGroup = React.forwardRef<HTMLInputElement, IProps>(
-  ({ name, label, error, type = 'text', className, isInvalid, groupPrefix, groupSuffix, groupClassName, ...rest }, ref) => {
-    let prefix = groupPrefix;
-    if (typeof groupPrefix === 'string') {
-      prefix = <span className="input-group-text">{groupPrefix}</span>;
-    }
-    let suffix = groupSuffix;
-    if (typeof groupSuffix === 'string') {
-      suffix = <span className="input-group-text">{groupSuffix}</span>;
-    }
+export const InputGroup = ({
+  name,
+  label,
+  error,
+  type = 'text',
+  className,
+  isInvalid,
+  groupPrefix,
+  groupSuffix,
+  groupClassName,
+  ...rest
+}: IProps) => {
+  let prefix = groupPrefix;
+  if (typeof groupPrefix === 'string') {
+    prefix = <span className="input-group-text">{groupPrefix}</span>;
+  }
+  let suffix = groupSuffix;
+  if (typeof groupSuffix === 'string') {
+    suffix = <span className="input-group-text">{groupSuffix}</span>;
+  }
 
-    return (
-      <div className={clsx(className)}>
-        {label && (
-          <label htmlFor={name} className="form-label">
-            {label}
-          </label>
-        )}
-        <div className={clsx('input-group', groupClassName)}>
-          {prefix}
-          <input
-            suppressHydrationWarning
-            aria-label={name}
-            type={type}
-            name={name}
-            id={name}
-            ref={ref}
-            className={clsx('form-control', { 'is-invalid is-invalid-lite': error || isInvalid })}
-            {...rest}
-          />
-          {suffix}
-          {error && <div className="invalid-feedback">{error}</div>}
-        </div>
+  return (
+    <div className={clsx(className)}>
+      {label && (
+        <label htmlFor={name} className="form-label">
+          {label}
+        </label>
+      )}
+      <div className={clsx('input-group', groupClassName)}>
+        {prefix}
+        <input
+          suppressHydrationWarning
+          aria-label={name}
+          type={type}
+          name={name}
+          id={name}
+          className={clsx('form-control', { 'is-invalid is-invalid-lite': error || isInvalid })}
+          {...rest}
+        />
+        {suffix}
+        {error && <div className="invalid-feedback">{error}</div>}
       </div>
-    );
-  },
-);
+    </div>
+  );
+};

--- a/packages/frontend/src/components/ui/Pagination/Pagination.tsx
+++ b/packages/frontend/src/components/ui/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 
 import { IconChevronLeft, IconChevronRight, IconDots } from '@tabler/icons-react';
 import clsx from 'clsx';
@@ -10,15 +10,11 @@ const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
 );
 Pagination.displayName = 'Pagination';
 
-const PaginationContent = React.forwardRef<HTMLUListElement, React.ComponentProps<'ul'>>(({ className, ...props }, ref) => (
-  <ul ref={ref} className={clsx('pagination', className)} {...props} />
-));
-PaginationContent.displayName = 'PaginationContent';
+const PaginationContent = ({ className, ...props }: React.ComponentProps<'ul'>) => <ul className={clsx('pagination', className)} {...props} />;
 
-const PaginationItem = React.forwardRef<HTMLLIElement, React.ComponentProps<'li'> & { isActive?: boolean }>(
-  ({ className, isActive, ...props }, ref) => <li ref={ref} className={clsx('page-item', { active: isActive }, className)} {...props} />,
+const PaginationItem = ({ className, isActive, ...props }: React.ComponentProps<'li'> & { isActive?: boolean }) => (
+  <li className={clsx('page-item', { active: isActive }, className)} {...props} />
 );
-PaginationItem.displayName = 'PaginationItem';
 
 type PaginationLinkProps = {
   small?: boolean;

--- a/packages/frontend/src/components/ui/PasswordInput/PasswordInput.tsx
+++ b/packages/frontend/src/components/ui/PasswordInput/PasswordInput.tsx
@@ -8,18 +8,15 @@ import { useTranslation } from 'react-i18next';
 type Props = ComponentProps<typeof InputGroup> & {};
 
 export const PasswordInput = (props: Props) => {
-  const { ref, key, ...rest } = props;
   const [passwordVisible, setPasswordVisible] = useState(false);
 
   const { t } = useTranslation();
 
   return (
     <InputGroup
-      key={key}
-      ref={ref}
       type={passwordVisible ? 'text' : 'password'}
       groupClassName="input-group-flat"
-      {...rest}
+      {...props}
       groupSuffix={
         <span className="input-group-text">
           <Tooltip className="tooltip" anchorSelect=".toggle-password-visibility">

--- a/packages/frontend/src/components/ui/ScrollArea/ScrollArea.tsx
+++ b/packages/frontend/src/components/ui/ScrollArea/ScrollArea.tsx
@@ -2,15 +2,11 @@
 
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 import clsx from 'clsx';
-import * as React from 'react';
+import type * as React from 'react';
 import styles from './ScrollArea.module.css';
 
-const ScrollBar = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
->(({ className, orientation = 'vertical', ...props }, ref) => (
+const ScrollBar = ({ className, orientation = 'vertical', ...props }: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) => (
   <ScrollAreaPrimitive.ScrollAreaScrollbar
-    ref={ref}
     orientation={orientation}
     className={clsx(
       styles.scrollbar,
@@ -21,21 +17,16 @@ const ScrollBar = React.forwardRef<
   >
     <ScrollAreaPrimitive.ScrollAreaThumb className={clsx('position-relative rounded-pill bg-muted', orientation === 'vertical' && 'flex-grow-1')} />
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
-));
-ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+);
 
-const ScrollArea = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & { maxheight: number }
->(({ className, children, ...props }, ref) => (
-  <ScrollAreaPrimitive.Root ref={ref} className={clsx('position-relative overflow-hidden', className)} {...props}>
+const ScrollArea = ({ className, children, ...props }: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & { maxheight: number }) => (
+  <ScrollAreaPrimitive.Root className={clsx('position-relative overflow-hidden', className)} {...props}>
     <ScrollAreaPrimitive.Viewport style={{ maxHeight: props.maxheight }} className={clsx(styles.viewport, 'w-100')}>
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />
     <ScrollAreaPrimitive.Corner />
   </ScrollAreaPrimitive.Root>
-));
-ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+);
 
 export { ScrollArea, ScrollBar };

--- a/packages/frontend/src/components/ui/Select/Select.tsx
+++ b/packages/frontend/src/components/ui/Select/Select.tsx
@@ -3,7 +3,7 @@
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { IconCheck, IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import clsx from 'clsx';
-import * as React from 'react';
+import type * as React from 'react';
 
 type TriggerProps = {
   label?: string | React.ReactNode;
@@ -25,10 +25,15 @@ const Select: React.FC<
 const SelectValue = SelectPrimitive.Value;
 
 // Button
-const SelectTrigger = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & TriggerProps
->(({ className, error, label, children, value, onClear, ...props }, ref) => {
+const SelectTrigger = ({
+  className,
+  error,
+  label,
+  children,
+  value,
+  onClear,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & TriggerProps) => {
   return (
     <label htmlFor={props.name} className={clsx('w-100', className)}>
       {Boolean(label) && (
@@ -40,7 +45,6 @@ const SelectTrigger = React.forwardRef<
         <SelectPrimitive.Trigger
           id={props.name}
           aria-labelledby={props.name}
-          ref={ref}
           className={clsx('d-flex w-100 align-items-center justify-content-between form-select', {
             'is-invalid is-invalid-lite': error,
             'text-muted': !value,
@@ -53,15 +57,11 @@ const SelectTrigger = React.forwardRef<
       {error && <div className="invalid-feedback">{error}</div>}
     </label>
   );
-});
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+};
 
-const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+const SelectContent = ({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Content>) => (
   <SelectPrimitive.Portal>
-    <SelectPrimitive.Content ref={ref} style={{ zIndex: 2000 }} className={clsx('overflow-hidden dropdown-menu', className)} {...props}>
+    <SelectPrimitive.Content style={{ zIndex: 2000 }} className={clsx('overflow-hidden dropdown-menu', className)} {...props}>
       <SelectPrimitive.ScrollUpButton className="d-flex align-items-center justify-content-center">
         <IconChevronUp />
       </SelectPrimitive.ScrollUpButton>
@@ -71,21 +71,17 @@ const SelectContent = React.forwardRef<
       </SelectPrimitive.ScrollDownButton>
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
-));
-SelectContent.displayName = SelectPrimitive.Content.displayName;
-
-const SelectItem = React.forwardRef<React.ElementRef<typeof SelectPrimitive.Item>, React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>>(
-  ({ className, children, ...props }, ref) => (
-    <SelectPrimitive.Item ref={ref} className={clsx('position-relative d-flex align-items-center dropdown-item', className)} {...props}>
-      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-      <span style={{ right: 8 }} className="ms-2">
-        <SelectPrimitive.ItemIndicator>
-          <IconCheck size={20} />
-        </SelectPrimitive.ItemIndicator>
-      </span>
-    </SelectPrimitive.Item>
-  ),
 );
-SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectItem = ({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Item>) => (
+  <SelectPrimitive.Item className={clsx('position-relative d-flex align-items-center dropdown-item', className)} {...props}>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    <span style={{ right: 8 }} className="ms-2">
+      <SelectPrimitive.ItemIndicator>
+        <IconCheck size={20} />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+  </SelectPrimitive.Item>
+);
 
 export { Select, SelectValue, SelectTrigger, SelectContent, SelectItem };

--- a/packages/frontend/src/components/ui/Skeleton/Skeleton.tsx
+++ b/packages/frontend/src/components/ui/Skeleton/Skeleton.tsx
@@ -15,7 +15,11 @@ import type { GetPropDefTypes } from '../props/prop-def.js';
 type SkeletonElement = React.ElementRef<'span'>;
 type SkeletonOwnProps = GetPropDefTypes<typeof skeletonPropDefs>;
 interface SkeletonProps extends ComponentPropsWithout<'span', RemovedProps>, MarginProps, SkeletonOwnProps {}
-const Skeleton = React.forwardRef<SkeletonElement, SkeletonProps>((props, forwardedRef) => {
+
+// Separate the ref from the other props to avoid TypeScript errors
+type SkeletonComponentProps = SkeletonProps & { ref?: React.Ref<SkeletonElement> };
+
+const Skeleton = ({ ...props }: SkeletonComponentProps) => {
   const { children, className, loading, ...skeletonProps } = extractProps(props, skeletonPropDefs, marginPropDefs);
 
   if (!loading) return children;
@@ -24,7 +28,6 @@ const Skeleton = React.forwardRef<SkeletonElement, SkeletonProps>((props, forwar
 
   return (
     <Tag
-      ref={forwardedRef}
       aria-hidden
       className={clsx('rt-Skeleton', className)}
       data-inline-skeleton={React.isValidElement(children) ? undefined : true}
@@ -36,8 +39,7 @@ const Skeleton = React.forwardRef<SkeletonElement, SkeletonProps>((props, forwar
       {children}
     </Tag>
   );
-});
-Skeleton.displayName = 'Skeleton';
+};
 
 export { Skeleton };
 export type { SkeletonProps };

--- a/packages/frontend/src/components/ui/Switch/Switch.tsx
+++ b/packages/frontend/src/components/ui/Switch/Switch.tsx
@@ -2,23 +2,25 @@
 
 import * as SwitchPrimitives from '@radix-ui/react-switch';
 import clsx from 'clsx';
-import * as React from 'react';
+import type * as React from 'react';
 import './Switch.css';
 
 type RootProps = typeof SwitchPrimitives.Root;
 
-const Switch = React.forwardRef<React.ElementRef<RootProps>, React.ComponentPropsWithoutRef<RootProps> & { label?: string | React.ReactNode }>(
-  ({ className, label, ...props }, ref) => (
-    <label htmlFor={props.name} aria-labelledby={props.name} className={clsx('form-check form-switch form-check-sigle', className)}>
-      <SwitchPrimitives.Root aria-label={props.name} className="form-check-input switch-root" {...props} ref={ref}>
-        <SwitchPrimitives.Thumb />
-      </SwitchPrimitives.Root>
-      <span id={props.name} className="form-check-label text-muted">
-        {label}
-      </span>
-    </label>
-  ),
+type SwitchProps = React.ComponentPropsWithoutRef<RootProps> & {
+  label?: string | React.ReactNode;
+  ref?: React.Ref<React.ElementRef<RootProps>>;
+};
+
+const Switch = ({ className, label, ...props }: SwitchProps) => (
+  <label htmlFor={props.name} aria-labelledby={props.name} className={clsx('form-check form-switch form-check-sigle', className)}>
+    <SwitchPrimitives.Root aria-label={props.name} className="form-check-input switch-root" {...props}>
+      <SwitchPrimitives.Thumb />
+    </SwitchPrimitives.Root>
+    <span id={props.name} className="form-check-label text-muted">
+      {label}
+    </span>
+  </label>
 );
-Switch.displayName = SwitchPrimitives.Root.displayName;
 
 export { Switch };

--- a/packages/frontend/src/components/ui/Table/Table.tsx
+++ b/packages/frontend/src/components/ui/Table/Table.tsx
@@ -1,46 +1,24 @@
 import clsx from 'clsx';
-import * as React from 'react';
+import type * as React from 'react';
 
-const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(({ className, ...props }, ref) => (
+const Table = ({ className, ...props }: React.ComponentProps<'table'>) => (
   <div className="table-responsive">
-    <table ref={ref} className={clsx('table table-vcenter card-table', className)} {...props} />
+    <table className={clsx('table table-vcenter card-table', className)} {...props} />
   </div>
-));
-Table.displayName = 'Table';
+);
 
-const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(({ className, ...props }, ref) => (
-  <thead ref={ref} className={clsx('', className)} {...props} />
-));
-TableHeader.displayName = 'TableHeader';
+const TableHeader = ({ className, ...props }: React.ComponentProps<'thead'>) => <thead className={clsx('', className)} {...props} />;
 
-const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(({ className, ...props }, ref) => (
-  <tbody ref={ref} className={clsx('table-tbody', className)} {...props} />
-));
-TableBody.displayName = 'TableBody';
+const TableBody = ({ className, ...props }: React.ComponentProps<'tbody'>) => <tbody className={clsx('table-tbody', className)} {...props} />;
 
-const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(({ className, ...props }, ref) => (
-  <tfoot ref={ref} className={clsx('', className)} {...props} />
-));
-TableFooter.displayName = 'TableFooter';
+const TableFooter = ({ className, ...props }: React.ComponentProps<'tfoot'>) => <tfoot className={clsx('', className)} {...props} />;
 
-const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(({ className, ...props }, ref) => (
-  <tr ref={ref} className={clsx('', className)} {...props} />
-));
-TableRow.displayName = 'TableRow';
+const TableRow = ({ className, ...props }: React.ComponentProps<'tr'>) => <tr className={clsx('', className)} {...props} />;
 
-const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(({ className, ...props }, ref) => (
-  <th ref={ref} className={clsx('', className)} {...props} />
-));
-TableHead.displayName = 'TableHead';
+const TableHead = ({ className, ...props }: React.ComponentProps<'th'>) => <th className={clsx('', className)} {...props} />;
 
-const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(({ className, ...props }, ref) => (
-  <td ref={ref} className={clsx('', className)} {...props} />
-));
-TableCell.displayName = 'TableCell';
+const TableCell = ({ className, ...props }: React.ComponentProps<'td'>) => <td className={clsx('', className)} {...props} />;
 
-const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(({ className, ...props }, ref) => (
-  <caption ref={ref} className={clsx('', className)} {...props} />
-));
-TableCaption.displayName = 'TableCaption';
+const TableCaption = ({ className, ...props }: React.ComponentProps<'caption'>) => <caption className={clsx('', className)} {...props} />;
 
 export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/packages/frontend/src/components/ui/tabs/tabs.tsx
+++ b/packages/frontend/src/components/ui/tabs/tabs.tsx
@@ -2,46 +2,35 @@
 
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 import clsx from 'clsx';
-import * as React from 'react';
+import type * as React from 'react';
 import './tabs.css';
 
-const Tabs = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Root>, React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>>(
-  ({ className, children, ...props }, ref) => (
-    <TabsPrimitive.Root ref={ref} className={clsx('card', className)} {...props}>
-      {children}
-    </TabsPrimitive.Root>
-  ),
+const Tabs = ({ className, children, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) => (
+  <TabsPrimitive.Root className={clsx('card', className)} {...props}>
+    {children}
+  </TabsPrimitive.Root>
 );
 
-const TabsList = React.forwardRef<React.ElementRef<typeof TabsPrimitive.List>, React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>>(
-  ({ className, children, ...props }, ref) => (
-    <TabsPrimitive.List ref={ref} className={clsx('', className)} {...props}>
-      <div className="card-header">
-        <div className="nav nav-tabs card-header-tabs">{children}</div>
-      </div>
-    </TabsPrimitive.List>
-  ),
+const TabsList = ({ className, children, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) => (
+  <TabsPrimitive.List className={clsx('', className)} {...props}>
+    <div className="card-header">
+      <div className="nav nav-tabs card-header-tabs">{children}</div>
+    </div>
+  </TabsPrimitive.List>
 );
-TabsList.displayName = TabsPrimitive.List.displayName;
 
-const TabsTrigger = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Trigger>, React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>>(
-  ({ className, children, ...props }, ref) => {
-    return (
-      <TabsPrimitive.Trigger className={clsx('trigger nav-link', className)} {...props} ref={ref}>
-        <li className="nav-item">{children}</li>
-      </TabsPrimitive.Trigger>
-    );
-  },
-);
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+const TabsTrigger = ({ className, children, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) => {
+  return (
+    <TabsPrimitive.Trigger className={clsx('trigger nav-link', className)} {...props}>
+      <li className="nav-item">{children}</li>
+    </TabsPrimitive.Trigger>
+  );
+};
 
-const TabsContent = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Content>, React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>>(
-  ({ className, children, ...props }, ref) => (
-    <TabsPrimitive.Content className={clsx('', className)} {...props} ref={ref}>
-      <div className="card-body">{children}</div>
-    </TabsPrimitive.Content>
-  ),
+const TabsContent = ({ className, children, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) => (
+  <TabsPrimitive.Content className={clsx('', className)} {...props}>
+    <div className="card-body">{children}</div>
+  </TabsPrimitive.Content>
 );
-TabsContent.displayName = TabsPrimitive.Content.displayName;
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };


### PR DESCRIPTION
Now the ref is automatically passed in props as of React 19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified multiple UI components by removing ref forwarding and converting them to standard functional components.
  * Updated component typings for consistency and maintainability.
  * Removed unused displayName assignments and streamlined prop handling.
  * No changes to component appearance or behavior are expected for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->