### PR TITLE
i18n: change appstore category selector text

### DIFF
--- a/packages/backend/src/modules/i18n/translations/en-US.json
+++ b/packages/backend/src/modules/i18n/translations/en-US.json
@@ -300,7 +300,7 @@
   "SERVER_ERROR_DUPLICATE_APP_STORE_NAME": "An app store with the same name already exists",
   "APP_STORE_CLONE_ERROR": "Error cloning app store at {{url}}. Is it a valid git repository?",
   "APP_STORE_CHOOSE_CATEGORY": "Choose a category",
-  "APP_STORE_CHOOSE_STORE": "Choose an AppStore",
+  "APP_STORE_CHOOSE_STORE": "Choose an appstore",
   "SETTINGS_ACTIONS_ALREADY_LATEST": "Already up to date",
   "SETTINGS_ACTIONS_CURRENT_VERSION": "Current version: {{version}}",
   "SETTINGS_ACTIONS_MAINTENANCE_SUBTITLE": "Common actions to perform on your instance",

--- a/packages/backend/src/modules/i18n/translations/en.json
+++ b/packages/backend/src/modules/i18n/translations/en.json
@@ -300,7 +300,7 @@
   "SERVER_ERROR_DUPLICATE_APP_STORE_NAME": "An app store with the same name already exists",
   "APP_STORE_CLONE_ERROR": "Error cloning app store at {{url}}. Is it a valid git repository?",
   "APP_STORE_CHOOSE_CATEGORY": "Choose a category",
-  "APP_STORE_CHOOSE_STORE": "Choose an AppStore",
+  "APP_STORE_CHOOSE_STORE": "Choose an appstore",
   "SETTINGS_ACTIONS_ALREADY_LATEST": "Already up to date",
   "SETTINGS_ACTIONS_CURRENT_VERSION": "Current version: {{version}}",
   "SETTINGS_ACTIONS_MAINTENANCE_SUBTITLE": "Common actions to perform on your instance",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized English copy for the app store selection prompt to “Choose an appstore” across English locales (en, en-US).
  * Visible on screens where users select an app store, improving readability and consistency in the interface.
  * Text-only change; no impact on functionality, settings, or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->