### PR TITLE
refactor: make max store tile app title length 15 characters

### DIFF
--- a/packages/frontend/src/modules/app/components/store-tile/store-tile.tsx
+++ b/packages/frontend/src/modules/app/components/store-tile/store-tile.tsx
@@ -24,7 +24,7 @@ export const StoreTile: React.FC<{ app: AppInfoSimple; isLoading: boolean }> = (
         <div className="card-body">
           <div className="d-flex align-items-center" style={{ columnGap: '0.75rem' }}>
             <h3 className="text-bold h-3 mb-2">
-              <Skeleton loading={isLoading}>{limitText(app.name, 20)}</Skeleton>
+              <Skeleton loading={isLoading}>{limitText(app.name, 15)}</Skeleton>
             </h3>
             {isNew ? <div className="text-white badge me-1 bg-green">{t('APP_NEW')}</div> : null}
           </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Updated app name display in Store tiles to truncate at 15 characters (previously 20), preventing layout overflow and ensuring consistent alignment across cards.
  * Visual elements such as loading skeleton, “New” badge, short description, and category tags remain unchanged; no changes to interactions or functionality.
  * Improves readability of longer app names on narrow viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->