### PR TITLE
refactor: disable port input if force expose is set

### DIFF
--- a/packages/frontend/src/modules/app/components/install-form/install-form.tsx
+++ b/packages/frontend/src/modules/app/components/install-form/install-form.tsx
@@ -68,6 +68,7 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
       setValue('openPort', false);
     }
   }, [info.force_expose, setValue]);
+
   useEffect(() => {
     if (initialValues && !isDirty) {
       for (const [key, value] of Object.entries(initialValues)) {
@@ -239,13 +240,13 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
           )}
         />
       )}
-      {info.dynamic_config && info.force_expose && (
+      {info.dynamic_config && (
         <div className="mb-3">
           <h3>{t('APP_DETAILS_PORT')}</h3>
           <Controller
             control={control}
             name="openPort"
-            defaultValue={true}
+            defaultValue={!info.force_expose}
             render={({ field: { onChange, value, ref, ...props } }) => (
               <Switch
                 {...props}
@@ -253,6 +254,7 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
                 ref={ref}
                 checked={value}
                 onCheckedChange={onChange}
+                disabled={info.force_expose}
                 label={
                   <>
                     {t('APP_INSTALL_FORM_OPEN_PORT')}

--- a/packages/frontend/src/modules/app/components/install-form/install-form.tsx
+++ b/packages/frontend/src/modules/app/components/install-form/install-form.tsx
@@ -65,10 +65,9 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
   useEffect(() => {
     if (info.force_expose) {
       setValue('exposed', true);
-      setValhe('openPort', false);
+      setValue('openPort', false);
     }
   }, [info.force_expose, setValue]);
-
   useEffect(() => {
     if (initialValues && !isDirty) {
       for (const [key, value] of Object.entries(initialValues)) {

--- a/packages/frontend/src/modules/app/components/install-form/install-form.tsx
+++ b/packages/frontend/src/modules/app/components/install-form/install-form.tsx
@@ -65,6 +65,7 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
   useEffect(() => {
     if (info.force_expose) {
       setValue('exposed', true);
+      setValhe('openPort', false);
     }
   }, [info.force_expose, setValue]);
 
@@ -239,14 +240,13 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
           )}
         />
       )}
-      {info.dynamic_config && (
+      {info.dynamic_config && info.force_expose && (
         <div className="mb-3">
           <h3>{t('APP_DETAILS_PORT')}</h3>
           <Controller
             control={control}
             name="openPort"
-            defaultValue={!info.force_expose}
-            disabled={info.force_expose}
+            defaultValue={true}
             render={({ field: { onChange, value, ref, ...props } }) => (
               <Switch
                 {...props}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Port exposure toggle now initializes reliably and reflects the forced-expose state.
  * When forced exposure is active, the toggle is set off and disabled; when not forced, users can interact with it.
  * The port settings panel remains visible only when dynamic configuration is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->