### PR TITLE
fix: disable port when app is force exposed

### DIFF
--- a/packages/frontend/src/modules/app/components/install-form/install-form.tsx
+++ b/packages/frontend/src/modules/app/components/install-form/install-form.tsx
@@ -57,7 +57,7 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
     control,
   } = useForm<FormValues>({});
   const watchExposed = watch('exposed', false);
-  const watchOpenPort = watch('openPort', true);
+  const watchOpenPort = watch('openPort', !info.force_expose);
   const watchExposedLocal = watch('exposedLocal', false);
 
   const { appName, appStoreId } = extractAppUrn(info.urn as AppUrn);
@@ -68,14 +68,11 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
         setValue(key, value as string);
       }
     }
-  }, [initialValues, isDirty, setValue]);
-
-  useEffect(() => {
     if (info.force_expose) {
       setValue('exposed', true);
       setValue('openPort', false);
     }
-  }, [info.force_expose, setValue]);
+  }, [initialValues, isDirty, setValue, info.force_expose]);
 
   const randomPortMutation = useMutation({
     ...getRandomPortMutation(),
@@ -294,11 +291,15 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
           )}
         </div>
       )}
-      {Boolean(info.port) && (
+      {info.exposable && (
         <>
-          {info.exposable && info.dynamic_config && <h3>{t('APP_INSTALL_FORM_REVERSE_PROXY')}</h3>}
-          {info.dynamic_config && renderDynamicConfigProxyForm()}
-          {info.exposable && renderExposeForm()}
+          {info.dynamic_config && info.exposable && (
+            <>
+              <h3>{t('APP_INSTALL_FORM_REVERSE_PROXY')}</h3>
+              {renderDynamicConfigProxyForm()}
+            </>
+          )}
+          {renderExposeForm()}
         </>
       )}
     </form>

--- a/packages/frontend/src/modules/app/components/install-form/install-form.tsx
+++ b/packages/frontend/src/modules/app/components/install-form/install-form.tsx
@@ -293,7 +293,7 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
       )}
       {info.exposable && (
         <>
-          {info.dynamic_config && info.exposable && (
+          {info.dynamic_config && (
             <>
               <h3>{t('APP_INSTALL_FORM_REVERSE_PROXY')}</h3>
               {renderDynamicConfigProxyForm()}

--- a/packages/frontend/src/modules/app/components/install-form/install-form.tsx
+++ b/packages/frontend/src/modules/app/components/install-form/install-form.tsx
@@ -63,19 +63,19 @@ export const InstallForm: React.FC<IProps> = ({ formFields = [], info, onSubmit,
   const { appName, appStoreId } = extractAppUrn(info.urn as AppUrn);
 
   useEffect(() => {
-    if (info.force_expose) {
-      setValue('exposed', true);
-      setValue('openPort', false);
-    }
-  }, [info.force_expose, setValue]);
-
-  useEffect(() => {
     if (initialValues && !isDirty) {
       for (const [key, value] of Object.entries(initialValues)) {
         setValue(key, value as string);
       }
     }
   }, [initialValues, isDirty, setValue]);
+
+  useEffect(() => {
+    if (info.force_expose) {
+      setValue('exposed', true);
+      setValue('openPort', false);
+    }
+  }, [info.force_expose, setValue]);
 
   const randomPortMutation = useMutation({
     ...getRandomPortMutation(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected initialization so "Expose service" and "Open port" reflect forced exposure on load; improves default consistency.
  * Updated form rendering: the bottom section now appears only for exposable services; dynamic proxy controls show only when dynamic configuration is available while expose controls remain visible where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->