### PR TITLE
fix: remove legacy code to load .arm64 files

### DIFF
--- a/packages/backend/src/modules/apps/app-files-manager.ts
+++ b/packages/backend/src/modules/apps/app-files-manager.ts
@@ -58,7 +58,7 @@ export class AppFilesManager {
           return { ...parsedConfig.data, description };
         }
       }
-    } catch (error) {
+    } catch (_) {
       return null;
     }
   }
@@ -69,13 +69,8 @@ export class AppFilesManager {
    * @returns The content of docker-compose.yml as a string, or null if not found
    */
   public async getDockerComposeYaml(appUrn: AppUrn) {
-    const arch = this.configuration.get('architecture');
     const { appInstalledDir } = this.getAppPaths(appUrn);
-    let dockerComposePath = path.join(appInstalledDir, 'docker-compose.yml');
-
-    if (arch === 'arm64' && (await this.filesystem.pathExists(path.join(appInstalledDir, 'docker-compose.arm64.yml')))) {
-      dockerComposePath = path.join(appInstalledDir, 'docker-compose.arm64.yml');
-    }
+    const dockerComposePath = path.join(appInstalledDir, 'docker-compose.yml');
 
     let content = null;
     try {


### PR DESCRIPTION
Closes #2344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized Docker Compose handling: the system now always uses docker-compose.yml across all architectures, simplifying setup and reducing configuration differences.
* **Bug Fixes**
  * Prevents architecture-specific compose file mismatches by consistently loading the primary docker-compose.yml, improving reliability on all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->