### PR TITLE
test: fix e2e backup restore

### DIFF
--- a/e2e/0006-backup-restore.spec.ts
+++ b/e2e/0006-backup-restore.spec.ts
@@ -50,7 +50,7 @@ test('user can backup and restore an app', async ({ page, isMobile }) => {
   await expect(page.getByText('App whoami updated successfully')).toBeVisible({ timeout: 100000 });
   
   dbapp = await db.query.app.findFirst({ where: eq(app.appName, 'whoami') });
-  expect(dbapp?.version).toBe(1);
+  await expect(dbapp?.version).toBe(1);
 
   if (isMobile) {
     await page.getByRole('button', { name: 'More' }).click();
@@ -66,10 +66,10 @@ test('user can backup and restore an app', async ({ page, isMobile }) => {
   await expect(page.getByText('Running')).toBeVisible({ timeout: 60000 });
 
   dbapp = await db.query.app.findFirst({ where: eq(app.appName, 'whoami') });
-  expect(dbapp?.version).toBe(0);
+  await expect(dbapp?.version).toBe(0);
   file = await readFile(path.join('apps', store.slug, 'whoami', 'config.json'));
   const restoredConfig = JSON.parse(file);
-  expect(restoredConfig.tipi_version).toBe(0);
+  await expect(restoredConfig.tipi_version).toBe(0);
 });
 
 test('user config is preserved when restoring from a backup', async ({ page, isMobile }) => {

--- a/e2e/0006-backup-restore.spec.ts
+++ b/e2e/0006-backup-restore.spec.ts
@@ -47,9 +47,8 @@ test('user can backup and restore an app', async ({ page, isMobile }) => {
   await page.getByRole('button', { name: 'Next' }).click();
   await page.getByRole('button', { name: 'Update' }).click();
 
-  await expect(page.getByText('Updating')).toBeVisible();
-  await expect(page.getByText('Running')).toBeVisible({ timeout: 60000 });
-
+  await expect(page.getByText('App whoami updated successfully')).toBeVisible({ timeout: 100000 });
+  
   dbapp = await db.query.app.findFirst({ where: eq(app.appName, 'whoami') });
   expect(dbapp?.version).toBe(1);
 

--- a/packages/backend/src/modules/app-lifecycle/app-lifecycle.service.ts
+++ b/packages/backend/src/modules/app-lifecycle/app-lifecycle.service.ts
@@ -478,13 +478,13 @@ export class AppLifecycleService {
         const appInfo = await this.appFilesManager.getInstalledAppInfo(appUrn);
 
         await this.updateAppConfig({ appUrn, form: app.config });
+        await this.appRepository.updateAppById(app.id, { version: appInfo?.tipi_version });
         this.sseService.emit('app', { event: 'update_success', appUrn });
 
         if (appStatusBeforeUpdate === 'running') {
-          await this.appRepository.updateAppById(app.id, { version: appInfo?.tipi_version });
           this.startApp({ appUrn });
         } else {
-          await this.appRepository.updateAppById(app.id, { status: appStatusBeforeUpdate, version: appInfo?.tipi_version });
+          await this.appRepository.updateAppById(app.id, { status: appStatusBeforeUpdate });
         }
       } else {
         this.logger.error(`Failed to update app ${appUrn}: ${message}`);


### PR DESCRIPTION
### Issue solved 

The `0006-backup-restore.spec.ts` e2e file was failing on the CI and in my local setup.
These changes should fix it.

### What was the problem
<img width="2048" height="1758" alt="image" src="https://github.com/user-attachments/assets/f03550c3-a315-4c53-9de4-fda24eed405b" />

As you can see in the image, app version in DB should be 1 instead of 0.
It should become 1 because the update is finished.
=> but in fact, this change was happening few second after.
=> the test was expecting 1 too early

### What did I do to fix

- change 1 : move `updateAppById` call that set with new app version 
  - put it before the sse emit update_success
  - this make sure that app version in DB have the right version number (1 instead of 0)
  - separate the logic in two purpose
    - one updateAppById to update version
    - the updateAppById to update status if not re-started

- change 2 : change text to watch in the test
   - search for “App whoami updated successfully” instead of “Running”
   - more precise because sometime I had flaky test (maybe Running was display from previous frontend state…)

- change 3 : (minor) : add missing await before expect

### Next actions

- enable e2e github action file
- after that, this e2e test can be flaky, I will do a second PR for other changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined app version update handling during backup restore operations to ensure consistent version synchronization.

* **Tests**
  * Enhanced end-to-end tests with improved assertions for verifying successful app updates and configuration restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->