### PR TITLE
test: improve  e2e backup restore - more text check between click

### DIFF
--- a/e2e/0006-backup-restore.spec.ts
+++ b/e2e/0006-backup-restore.spec.ts
@@ -34,6 +34,7 @@ test('user can backup and restore an app', async ({ page, isMobile }) => {
   await page.goto('/settings');
 
   await page.getByRole('button', { name: 'Update' }).click();
+  await expect(page.getByText('This will reset your appstores')).toBeVisible();
   await page.getByRole('button', { name: 'Update' }).click();
   await expect(page.getByText('Appstores updated successfully')).toBeVisible({ timeout: 10000 });
 
@@ -43,8 +44,11 @@ test('user can backup and restore an app', async ({ page, isMobile }) => {
   await page.getByRole('menuitem', { name: 'Update' }).click();
 
   await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByText('Review the new configuration of the app')).toBeVisible();
   await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByText('Review the changes in the docker-compose file')).toBeVisible();
   await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByText('It is highly recommended to backup')).toBeVisible();
   await page.getByRole('button', { name: 'Update' }).click();
 
   await expect(page.getByText('Updating')).toBeVisible();
@@ -61,6 +65,7 @@ test('user can backup and restore an app', async ({ page, isMobile }) => {
   }
 
   await page.getByRole('button', { name: 'Restore' }).click();
+  await expect(page.getByText('Do you really want to restore backup')).toBeVisible();
   await page.getByRole('button', { name: 'Restore' }).click();
 
   await expect(page.getByText('Restoring')).toBeVisible();


### PR DESCRIPTION
## Issue to solve

<img width="822" height="675" alt="CleanShot 2025-10-22 at 16 07 40" src="https://github.com/user-attachments/assets/f9ad2249-7930-4178-8063-a979a9aa85b5" />

Randomly I add this kind of test failed. 

## My suggestion to fix it

This test file has multiple steps where the button clicked has the same names but a different views.

click on Update => Update 
click on Next => Next => Next 
click on Restore => Restore

I think that the playwright robot click multiple times on the same button if it goes to fast and the new view is not render yet.

So I decided to had new 'expect text' between such steps to make il more robust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation coverage for the backup and restore workflow UI, ensuring proper confirmation prompts and informational text are displayed at each step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->