### PR TITLE
fix: update translation link in settings

### DIFF
--- a/packages/frontend/src/components/language-selector/language-selector.tsx
+++ b/packages/frontend/src/components/language-selector/language-selector.tsx
@@ -16,7 +16,7 @@ const LanguageSelectorLabel = () => {
   return (
     <span>
       {t('SETTINGS_GENERAL_LANGUAGE')}&nbsp;
-      <a href="https://crowdin.com/project/runtipi/invite?h=ae594e86cd807bc075310cab20a4aa921693663" target="_blank" rel="noreferrer">
+      <a href="https://crowdin.com/project/runtipi" target="_blank" rel="noreferrer">
         {t('SETTINGS_GENERAL_LANGUAGE_HELP_TRANSLATE')}
         <IconExternalLink className="ms-1 mb-1" size={16} />
       </a>


### PR DESCRIPTION
The current one is expired and broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the translation help link in the language selector to point to the project homepage instead of a specific invite URL, making it easier for users to access translation resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->