### PR TITLE
fix: auto focus totp

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,6 @@
 pre-commit:
   commands:
     biome-format:
-      glob: "*.{js,jsx,ts,tsx,json,jsonc}"
-      run: biome check --write --unsafe {staged_files}
+      glob: '*.{js,jsx,ts,tsx,json,jsonc}'
+      run: bunx biome check --write --unsafe {staged_files}
       stage_fixed: true

--- a/packages/frontend/src/components/ui/OtpInput/OtpInput.tsx
+++ b/packages/frontend/src/components/ui/OtpInput/OtpInput.tsx
@@ -151,6 +151,8 @@ export const OtpInput = ({ value, valueLength, onChange, className }: Props) => 
           maxLength={valueLength}
           className={clsx('form-control otp-input', className)}
           value={digit}
+          // biome-ignore lint/a11y/noAutofocus: Required for better UX
+          autoFocus
         />
       ))}
     </div>

--- a/packages/frontend/src/components/ui/OtpInput/OtpInput.tsx
+++ b/packages/frontend/src/components/ui/OtpInput/OtpInput.tsx
@@ -135,7 +135,8 @@ export const OtpInput = ({ value, valueLength, onChange, className }: Props) => 
   };
 
   return (
-    <div className="otp-group">
+    // biome-ignore lint/a11y/noAutofocus: Required for better UX
+    <div className="otp-group" autoFocus>
       {valueItems.map((digit, idx) => (
         <input
           aria-label={`digit-${idx}`}
@@ -151,8 +152,6 @@ export const OtpInput = ({ value, valueLength, onChange, className }: Props) => 
           maxLength={valueLength}
           className={clsx('form-control otp-input', className)}
           value={digit}
-          // biome-ignore lint/a11y/noAutofocus: Required for better UX
-          autoFocus
         />
       ))}
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OTP input now auto-focuses on render so users can start typing digits immediately without extra clicks.
  * Improves keyboard and form entry flow during verification, reducing friction when entering one-time passwords and speeding up completion of authentication steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->