### PR TITLE
fix(instal-script): add support for cachyos

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -75,7 +75,7 @@ function install_generic() {
   elif [[ "${os}" == "fedora" ]]; then
     sudo dnf -y install "${dependency}"
     return 0
-  elif [[ "${os}" == "arch" || "${os}" == "manjaro" ]]; then
+  elif [[ "${os}" == "arch" || "${os}" == "manjaro" || "${os}" == "cachyos" ]]; then
     if ! sudo pacman -Sy --noconfirm "${dependency}"; then
       if command -v yay >/dev/null 2>&1; then
         sudo -u "$SUDO_USER" yay -Sy --noconfirm "${dependency}"
@@ -126,7 +126,7 @@ function install_docker() {
     sudo systemctl start docker
     sudo systemctl enable docker
     return 0
-  elif [[ "${os}" == "arch" || "${os}" == "manjaro" ]]; then
+  elif [[ "${os}" == "arch" || "${os}" == "manjaro" || "${os}" == "cachyos" ]]; then
     sudo pacman -Sy --noconfirm docker docker-compose
     sudo systemctl start docker.service
     sudo systemctl enable docker.service


### PR DESCRIPTION
Closes #2541


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended installation script support to include CachyOS systems, treating them alongside other Arch-based distributions for dependency and Docker installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->