### PR TITLE
fix: ensure udp ports get added to generated compose files

### DIFF
--- a/packages/common/src/schemas/utils/convert-legacy-schema.ts
+++ b/packages/common/src/schemas/utils/convert-legacy-schema.ts
@@ -73,15 +73,22 @@ const convertService = (service: Partial<Service>) => {
     deploy,
   } = service;
 
-  const ports = addPorts?.map((port) => {
-    const { interface: iface, hostPort, containerPort, tcp, udp } = port;
+  let ports: string[] | undefined;
 
-    if (tcp && udp) {
-      return `${iface ? `${iface}:` : ''}${hostPort}:${containerPort}`;
+  if (typeof addPorts !== 'undefined') {
+    ports = [];
+    for (const port of addPorts) {
+      const { interface: iface, hostPort, containerPort, tcp, udp } = port;
+
+      if (tcp && udp) {
+        ports.push(`${iface ? `${iface}:` : ''}${hostPort}:${containerPort}/tcp`);
+        ports.push(`${iface ? `${iface}:` : ''}${hostPort}:${containerPort}/udp`);
+        continue;
+      }
+
+      ports.push(`${iface ? `${iface}:` : ''}${hostPort}:${containerPort}${tcp ? '/tcp' : ''}${udp ? '/udp' : ''}`);
     }
-
-    return `${iface ? `${iface}:` : ''}${hostPort}:${containerPort}${tcp ? '/tcp' : ''}${udp ? '/udp' : ''}`;
-  });
+  }
 
   const envVars = environment?.map((env) => {
     return `${env.key}=${env.value}`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated service port handling to generate separate TCP and UDP entries when both protocols are specified, replacing the previous combined single-entry approach. Services with single-protocol specifications maintain existing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->