### PR TITLE
Addition to the translation key for "YOUR ACCOUNT" on the login page

### DIFF
--- a/packages/backend/src/modules/i18n/translations/en-US.json
+++ b/packages/backend/src/modules/i18n/translations/en-US.json
@@ -362,6 +362,7 @@
   "AUTH_FORM_PASSWORD_PLACEHOLDER": "Enter your password",
   "AUTH_LOGIN_SUBMIT": "Login",
   "AUTH_LOGIN_TITLE": "Login to {{type}}",
+  "AUTH_LOGIN_TYPE_ACCOUNT": "your account",
   "AUTH_REGISTER_SUBMIT": "Register",
   "AUTH_REGISTER_TITLE": "Register your account",
   "AUTH_RESET_PASSWORD_BACK_TO_LOGIN": "Back to login",

--- a/packages/backend/src/modules/i18n/translations/en.json
+++ b/packages/backend/src/modules/i18n/translations/en.json
@@ -362,6 +362,7 @@
   "AUTH_FORM_PASSWORD_PLACEHOLDER": "Enter your password",
   "AUTH_LOGIN_SUBMIT": "Login",
   "AUTH_LOGIN_TITLE": "Login to {{type}}",
+  "AUTH_LOGIN_TYPE_ACCOUNT": "your account",
   "AUTH_REGISTER_SUBMIT": "Register",
   "AUTH_REGISTER_TITLE": "Register your account",
   "AUTH_RESET_PASSWORD_BACK_TO_LOGIN": "Back to login",

--- a/packages/frontend/src/modules/auth/pages/login-page.tsx
+++ b/packages/frontend/src/modules/auth/pages/login-page.tsx
@@ -33,10 +33,10 @@ export default () => {
   const redirect_url = searchParams.get('redirect_url');
   const app = searchParams.get('app');
 
-  const loginType = capitalize(app ?? '') || 'your account';
-
   const { t } = useTranslation();
   const navigate = useNavigate();
+
+  const loginType = capitalize(app ?? '') || t('AUTH_LOGIN_TYPE_ACCOUNT');
 
   const login = useMutation({
     ...loginMutation(),


### PR DESCRIPTION
There was no translation key for "YOUR ACCOUNT" used if no app name used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Login page now uses the translation system instead of a hard-coded fallback, improving localization handling.

* **New Features**
  * Added English translation entry for the login type label ("your account"), enabling i18n-aware fallback text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->