### PR TITLE
fix: allow extra top-level keys in custom docker compose yaml

### DIFF
--- a/packages/backend/src/modules/app-config/__tests__/app-config.service.test.ts
+++ b/packages/backend/src/modules/app-config/__tests__/app-config.service.test.ts
@@ -407,8 +407,35 @@ describe('AppConfigService', () => {
       await service.syncWithTemplate(mockAppUrn);
 
       // Assert
-      const expectedYaml = yaml.stringify(templateConfig);
+      const expectedYaml = yaml.stringify(templateConfig, { nullStr: '' });
       expect(mockFilesystem.writeTextFile).toHaveBeenCalledWith(mockConfigPath, expectedYaml);
+    });
+
+    it('should preserve empty named volumes without writing null when syncing object template content', async () => {
+      // Arrange
+      const templateConfig = { volumes: { nginx_logs: null }, services: { app: { image: 'test-image' } } };
+      const mockApp = fromPartial({
+        id: faker.number.int(),
+        templateUrn: 'template:test-store',
+        templateVersion: 1,
+      });
+      mockAppsRepository.getAppByUrn.mockResolvedValue(fromAny(mockApp));
+      mockMarketplaceService.getSourceDockerComposeYaml.mockResolvedValue(fromAny({ content: templateConfig }));
+      mockFilesystem.readTextFile.mockResolvedValue('old-config');
+      mockFilesystem.writeTextFile.mockResolvedValue(true);
+      mockAppsRepository.updateAppById.mockResolvedValue(fromAny(mockApp));
+
+      // Act
+      await service.syncWithTemplate(mockAppUrn);
+
+      // Assert
+      expect(mockFilesystem.writeTextFile).toHaveBeenCalledWith(
+        mockConfigPath,
+        expect.stringContaining(`volumes:
+  nginx_logs:
+`),
+      );
+      expect(mockFilesystem.writeTextFile).not.toHaveBeenCalledWith(mockConfigPath, expect.stringContaining('nginx_logs: null'));
     });
 
     it('should extract template version from x-runtipi schema_version when syncing', async () => {

--- a/packages/backend/src/modules/app-config/app-config.service.ts
+++ b/packages/backend/src/modules/app-config/app-config.service.ts
@@ -96,9 +96,11 @@ export class AppConfigService {
       throw new TranslatableError('APP_ERROR_APP_NOT_FOUND', { id: appUrn }, HttpStatus.NOT_FOUND);
     }
 
-    const localContentStr = localResult.content ? yaml.stringify(localResult.content) : '';
+    const localContentStr = localResult.content ? yaml.stringify(localResult.content, { nullStr: '' }) : '';
     const templateContentStr =
-      typeof templateConfig.content === 'string' ? yaml.stringify(yaml.parse(templateConfig.content)) : yaml.stringify(templateConfig.content);
+      typeof templateConfig.content === 'string'
+        ? yaml.stringify(yaml.parse(templateConfig.content), { nullStr: '' })
+        : yaml.stringify(templateConfig.content, { nullStr: '' });
 
     const hasChanges = localContentStr !== templateContentStr;
 
@@ -136,7 +138,8 @@ export class AppConfigService {
 
     await this.backupConfig(appUrn);
 
-    const templateContentStr = typeof templateConfig.content === 'string' ? templateConfig.content : yaml.stringify(templateConfig.content);
+    const templateContentStr =
+      typeof templateConfig.content === 'string' ? templateConfig.content : yaml.stringify(templateConfig.content, { nullStr: '' });
 
     await this.updateAppConfig(appUrn, { config: templateContentStr });
 

--- a/packages/backend/src/modules/custom-apps/custom-apps.service.ts
+++ b/packages/backend/src/modules/custom-apps/custom-apps.service.ts
@@ -117,7 +117,7 @@ export class CustomAppService {
 
   private async writeDockerComposeConfig(appUrn: AppUrn, config: CreateCustomAppDto['config']): Promise<void> {
     const { composePath } = this.getCustomAppPaths(appUrn);
-    const configContent = yaml.stringify(config);
+    const configContent = yaml.stringify(config, { nullStr: '' });
 
     const ok = await this.filesystem.writeTextFile(composePath, configContent);
     if (!ok) {

--- a/packages/backend/src/modules/docker/builders/__tests__/compose.builder.test.ts
+++ b/packages/backend/src/modules/docker/builders/__tests__/compose.builder.test.ts
@@ -429,6 +429,23 @@ services:
       // Check root x-runtipi removed
       expect(resultParsed['x-runtipi']).toBeUndefined();
     });
+
+    it('should preserve empty named volumes without rendering null', () => {
+      const doc = `services:
+  web:
+    image: nginx:alpine
+volumes:
+  nginx_logs:
+`;
+
+      const parsed = yaml.parse(doc);
+      const result = composeBuilder.getDockerCompose(parsed, { openPort: true, domain: 'hello.com', exposed: true }, urn, subnet);
+
+      expect(result).toContain(`volumes:
+  nginx_logs:
+`);
+      expect(result).not.toContain('nginx_logs: null');
+    });
   });
 
   describe('Network mode exclusivity', () => {

--- a/packages/backend/src/modules/docker/builders/compose.builder.ts
+++ b/packages/backend/src/modules/docker/builders/compose.builder.ts
@@ -208,6 +208,6 @@ export class DockerComposeBuilder {
       '\n',
     );
 
-    return header + yaml.stringify(inputCopy);
+    return header + yaml.stringify(inputCopy, { nullStr: '' });
   };
 }

--- a/packages/frontend/src/components/multi-service-form/compose-editor.test.tsx
+++ b/packages/frontend/src/components/multi-service-form/compose-editor.test.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen } from '@/tests/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMultiServiceStore } from '@/stores/multiServiceStore';
+import { ComposeEditor } from './compose-editor';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@codemirror/lang-yaml', () => ({
+  yaml: () => [],
+}));
+
+vi.mock('@codemirror/lang-json', () => ({
+  json: () => [],
+}));
+
+vi.mock('@uiw/codemirror-theme-copilot', () => ({
+  copilot: {},
+}));
+
+vi.mock('@uiw/react-codemirror', () => ({
+  default: ({ value, onChange }: { value: string; onChange: (value: string) => void }) => (
+    <textarea aria-label="compose-editor" value={value} onChange={(event) => onChange(event.target.value)} />
+  ),
+}));
+
+vi.mock('@/components/ui/tabs/tabs', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  const TabsContext = React.createContext<{
+    onValueChange: (value: string) => void;
+    value: string;
+  }>({
+    onValueChange: () => {},
+    value: '',
+  });
+
+  return {
+    Tabs: ({ children, onValueChange, value }: { children: ReactNode; onValueChange: (value: string) => void; value: string }) => (
+      <TabsContext.Provider value={{ value, onValueChange }}>{children}</TabsContext.Provider>
+    ),
+    TabsList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    TabsTrigger: ({ children, disabled, value }: { children: ReactNode; disabled?: boolean; value: string }) => {
+      const context = React.useContext(TabsContext);
+
+      return (
+        <button type="button" disabled={disabled} onClick={() => context.onValueChange(value)}>
+          {children}
+        </button>
+      );
+    },
+  };
+});
+
+describe('ComposeEditor', () => {
+  beforeEach(() => {
+    useMultiServiceStore.getState().resetToDefaults();
+    useMultiServiceStore.getState().setComposeExtras({});
+  });
+
+  it('preserves unsaved YAML extras when switching to JSON and back', () => {
+    render(<ComposeEditor onChange={vi.fn()} />);
+
+    const yamlEditor = screen.getByRole('textbox', { name: 'compose-editor' }) as HTMLTextAreaElement;
+    fireEvent.change(yamlEditor, {
+      target: {
+        value: `${yamlEditor.value.trimEnd()}\nvolumes:\n  app_data:\n`,
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'JSON' }));
+    fireEvent.click(screen.getByRole('button', { name: 'YAML' }));
+
+    const roundTripYamlEditor = screen.getByRole('textbox', { name: 'compose-editor' }) as HTMLTextAreaElement;
+
+    expect(roundTripYamlEditor.value).toContain('volumes:');
+    expect(roundTripYamlEditor.value).toContain('  app_data:');
+  });
+});

--- a/packages/frontend/src/components/multi-service-form/compose-editor.tsx
+++ b/packages/frontend/src/components/multi-service-form/compose-editor.tsx
@@ -25,7 +25,7 @@ const validateJson = ajv.compile(jsonSchema);
 
 export const ComposeEditor = ({ onChange, initialFormat = 'yaml' }: Props) => {
   const { t } = useTranslation();
-  const { services, setIsDirty, isDirty: isDirtyStore } = useMultiServiceStore();
+  const { services, composeExtras, setIsDirty, isDirty: isDirtyStore } = useMultiServiceStore();
   const [error, setError] = useState<string | undefined>(undefined);
   const [format, setFormat] = useState<'yaml' | 'json'>(initialFormat);
 
@@ -34,10 +34,13 @@ export const ComposeEditor = ({ onChange, initialFormat = 'yaml' }: Props) => {
     return deepClean({ services: servicesWithoutIds, schemaVersion: 2 });
   }, [services]);
 
+  const getCanonicalStoreYamlObject = useCallback(() => {
+    return deepClean({ ...convertLegacyToYaml(getCanonicalStoreObject()), ...composeExtras });
+  }, [composeExtras, getCanonicalStoreObject]);
+
   const [yamlValue, setYamlValue] = useState<string>(() => {
     try {
-      const legacy = getCanonicalStoreObject();
-      return stringify(convertLegacyToYaml(legacy));
+      return stringify(getCanonicalStoreYamlObject());
     } catch (e) {
       console.error('Failed to init yaml', e);
       return '';
@@ -64,16 +67,17 @@ export const ComposeEditor = ({ onChange, initialFormat = 'yaml' }: Props) => {
           return;
         }
 
-        let editorObj: unknown;
-
         if (currentFormat === 'yaml') {
-          const parsed = parse(currentVal);
-          editorObj = convertYamlToLegacy(parsed);
-        } else {
-          const parsed = JSON.parse(currentVal);
-          editorObj = { ...parsed, schemaVersion: 2 };
+          const editorObj = deepClean(parse(currentVal));
+          const storeYaml = getCanonicalStoreYamlObject();
+          const isDirty = JSON.stringify(editorObj) !== JSON.stringify(storeYaml);
+
+          setIsDirty(isDirty);
+          return;
         }
 
+        const parsed = JSON.parse(currentVal);
+        const editorObj = { ...parsed, schemaVersion: 2 };
         const isDirty = JSON.stringify(deepClean(editorObj)) !== JSON.stringify(deepClean(storeObj));
 
         setIsDirty(isDirty);
@@ -81,7 +85,7 @@ export const ComposeEditor = ({ onChange, initialFormat = 'yaml' }: Props) => {
         setIsDirty(true);
       }
     },
-    [getCanonicalStoreObject, setIsDirty],
+    [getCanonicalStoreObject, getCanonicalStoreYamlObject, setIsDirty],
   );
 
   const validateInput = useCallback(
@@ -174,7 +178,7 @@ export const ComposeEditor = ({ onChange, initialFormat = 'yaml' }: Props) => {
       } else {
         const parsedJson = JSON.parse(jsonValue);
         const legacyInput = { ...parsedJson, schemaVersion: 2 };
-        const yamlObj = convertLegacyToYaml(legacyInput);
+        const yamlObj = { ...convertLegacyToYaml(legacyInput), ...composeExtras };
         const newYaml = stringify(yamlObj);
 
         setYamlValue(newYaml);

--- a/packages/frontend/src/components/multi-service-form/compose-editor.tsx
+++ b/packages/frontend/src/components/multi-service-form/compose-editor.tsx
@@ -35,12 +35,12 @@ export const ComposeEditor = ({ onChange, initialFormat = 'yaml' }: Props) => {
   }, [services]);
 
   const getCanonicalStoreYamlObject = useCallback(() => {
-    return deepClean({ ...convertLegacyToYaml(getCanonicalStoreObject()), ...composeExtras });
+    return { ...deepClean(convertLegacyToYaml(getCanonicalStoreObject())), ...composeExtras };
   }, [composeExtras, getCanonicalStoreObject]);
 
   const [yamlValue, setYamlValue] = useState<string>(() => {
     try {
-      return stringify(getCanonicalStoreYamlObject());
+      return stringify(getCanonicalStoreYamlObject(), { nullStr: '' });
     } catch (e) {
       console.error('Failed to init yaml', e);
       return '';
@@ -178,8 +178,10 @@ export const ComposeEditor = ({ onChange, initialFormat = 'yaml' }: Props) => {
       } else {
         const parsedJson = JSON.parse(jsonValue);
         const legacyInput = { ...parsedJson, schemaVersion: 2 };
-        const yamlObj = { ...convertLegacyToYaml(legacyInput), ...composeExtras };
-        const newYaml = stringify(yamlObj);
+        const parsedYaml = parse(yamlValue) as Record<string, unknown>;
+        const yamlExtras = Object.fromEntries(Object.entries(parsedYaml).filter(([key]) => key !== 'services' && key !== 'x-runtipi'));
+        const yamlObj = { ...convertLegacyToYaml(legacyInput), ...yamlExtras };
+        const newYaml = stringify(yamlObj, { nullStr: '' });
 
         setYamlValue(newYaml);
         setFormat('yaml');

--- a/packages/frontend/src/modules/app/pages/app-edit-page.tsx
+++ b/packages/frontend/src/modules/app/pages/app-edit-page.tsx
@@ -75,7 +75,7 @@ export default function AppEditPage({ loaderData }: Route.ComponentProps) {
   });
 
   const onSubmit = (data: ReturnType<typeof convertYamlToLegacy>) => {
-    updateApp.mutate({ path: { urn }, body: { config: yaml.stringify({ ...convertLegacyToYaml(data), ...composeExtras }) } });
+    updateApp.mutate({ path: { urn }, body: { config: yaml.stringify({ ...convertLegacyToYaml(data), ...composeExtras }, { nullStr: '' }) } });
   };
 
   if (!ready) {

--- a/packages/frontend/src/modules/app/pages/app-edit-page.tsx
+++ b/packages/frontend/src/modules/app/pages/app-edit-page.tsx
@@ -37,7 +37,7 @@ export default function AppEditPage({ loaderData }: Route.ComponentProps) {
   const navigate = useNavigate();
   const [ready, setReady] = useState(false);
   const params = useParams<{ appId: string; storeId: string }>();
-  const { setServices } = useMultiServiceStore();
+  const { composeExtras, setComposeExtras, setServices } = useMultiServiceStore();
   const id = useId();
 
   const appName = params.appId ?? '';
@@ -47,11 +47,13 @@ export default function AppEditPage({ loaderData }: Route.ComponentProps) {
   useEffect(() => {
     if (loaderData?.config) {
       try {
-        const parsed = convertYamlToLegacy(JSON.parse(loaderData.config));
+        const yamlConfig = JSON.parse(loaderData.config) as Record<string, unknown>;
+        const parsed = convertYamlToLegacy(yamlConfig);
         const servicesWithId = parsed.services.map((service) => ({
           _id: id + Math.random().toString(36).substring(2, 9),
           ...service,
         }));
+        setComposeExtras(Object.fromEntries(Object.entries(yamlConfig).filter(([key]) => key !== 'services' && key !== 'x-runtipi')));
         setServices(servicesWithId);
         setReady(true);
       } catch (_e) {
@@ -59,7 +61,7 @@ export default function AppEditPage({ loaderData }: Route.ComponentProps) {
         navigate('/apps');
       }
     }
-  }, [loaderData, setServices, id, navigate, t]);
+  }, [loaderData, setComposeExtras, setServices, id, navigate, t]);
 
   const updateApp = useMutation({
     ...updateEditableAppConfigMutation(),
@@ -73,7 +75,7 @@ export default function AppEditPage({ loaderData }: Route.ComponentProps) {
   });
 
   const onSubmit = (data: ReturnType<typeof convertYamlToLegacy>) => {
-    updateApp.mutate({ path: { urn }, body: { config: yaml.stringify(convertLegacyToYaml(data)) } });
+    updateApp.mutate({ path: { urn }, body: { config: yaml.stringify({ ...convertLegacyToYaml(data), ...composeExtras }) } });
   };
 
   if (!ready) {

--- a/packages/frontend/src/modules/app/pages/app-update-page.tsx
+++ b/packages/frontend/src/modules/app/pages/app-update-page.tsx
@@ -160,13 +160,13 @@ export default function AppUpdatePage({ loaderData }: Route.ComponentProps) {
                   {!composeDiffQuery.isLoading && (
                     <ScrollArea maxheight={500} className="mt-3 border rounded">
                       <CodeMirror
-                        value={yaml.stringify(JSON.parse(composeDiffQuery.data?.new ?? '{}')) ?? ''}
+                        value={yaml.stringify(JSON.parse(composeDiffQuery.data?.new ?? '{}'), { nullStr: '' }) ?? ''}
                         readOnly
                         height="400px"
                         theme={copilot}
                         extensions={[
                           unifiedMergeView({
-                            original: yaml.stringify(JSON.parse(composeDiffQuery.data?.current ?? '{}')) ?? '',
+                            original: yaml.stringify(JSON.parse(composeDiffQuery.data?.current ?? '{}'), { nullStr: '' }) ?? '',
                             mergeControls: false,
                           }),
                         ]}

--- a/packages/frontend/src/modules/app/pages/custom-app-create-page.test.tsx
+++ b/packages/frontend/src/modules/app/pages/custom-app-create-page.test.tsx
@@ -1,0 +1,95 @@
+import type { ChangeEvent } from 'react';
+import { fireEvent, render, screen, waitFor } from '@/tests/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMultiServiceStore } from '@/stores/multiServiceStore';
+import CustomAppCreatePage from './custom-app-create-page';
+
+const mutate = vi.fn();
+const navigate = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({
+    isPending: false,
+    mutate,
+  }),
+}));
+
+vi.mock('@/api-client/@tanstack/react-query.gen', () => ({
+  createCustomAppMutation: () => ({}),
+}));
+
+vi.mock('@/components/ui/Input/Input', () => ({
+  Input: ({ disabled, error, onChange }: { disabled?: boolean; error?: string; onChange?: (event: ChangeEvent<HTMLInputElement>) => void }) => (
+    <div>
+      <input aria-label="app-name" disabled={disabled} onChange={onChange} />
+      {error && <span>{error}</span>}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/multi-service-form/multi-service-form', () => ({
+  MultiServiceForm: ({ onSubmit }: { onSubmit?: (data: { schemaVersion: 2; services: [] }) => void }) => (
+    <button type="button" onClick={() => onSubmit?.({ schemaVersion: 2, services: [] })}>
+      submit-services
+    </button>
+  ),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe('CustomAppCreatePage', () => {
+  beforeEach(() => {
+    mutate.mockReset();
+    navigate.mockReset();
+    useMultiServiceStore.getState().resetToDefaults();
+    useMultiServiceStore.getState().setComposeExtras({
+      volumes: {
+        stale_data: null,
+      },
+    });
+  });
+
+  it('does not submit stale compose extras carried over from another page', async () => {
+    render(<CustomAppCreatePage />);
+
+    await waitFor(() => {
+      expect(useMultiServiceStore.getState().composeExtras).toEqual({});
+    });
+
+    fireEvent.change(screen.getByLabelText('app-name'), { target: { value: 'my-custom-app' } });
+    fireEvent.click(screen.getByRole('button', { name: 'submit-services' }));
+
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledTimes(1);
+    });
+
+    const firstCall = mutate.mock.calls[0];
+    expect(firstCall).toBeDefined();
+
+    if (!firstCall) {
+      throw new Error('Expected mutation to be called');
+    }
+
+    expect(firstCall[0].body.config).not.toHaveProperty('volumes');
+  });
+});

--- a/packages/frontend/src/modules/app/pages/custom-app-create-page.tsx
+++ b/packages/frontend/src/modules/app/pages/custom-app-create-page.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/Input/Input';
 import type { TranslatableError } from '@/types/error.types';
 import { useState } from 'react';
 import { type } from 'arktype';
+import { useMultiServiceStore } from '@/stores/multiServiceStore';
 
 const RESERVED_APP_NAMES = ['create'];
 
@@ -17,6 +18,7 @@ export default () => {
   const navigate = useNavigate();
   const [appName, setAppName] = useState('');
   const [appNameError, setAppNameError] = useState<string>();
+  const { composeExtras } = useMultiServiceStore();
 
   const appNameSchema = type('string').narrow((name, ctx) => {
     if (name.length < 1) ctx.reject({ message: t('CUSTOM_APP_NAME_REQUIRED') });
@@ -71,7 +73,7 @@ export default () => {
           </div>
         </div>
       </div>
-      <MultiServiceForm onSubmit={(d) => onSubmit(convertLegacyToYaml(d))} />
+      <MultiServiceForm onSubmit={(d) => onSubmit({ ...convertLegacyToYaml(d), ...composeExtras })} />
     </>
   );
 };

--- a/packages/frontend/src/modules/app/pages/custom-app-create-page.tsx
+++ b/packages/frontend/src/modules/app/pages/custom-app-create-page.tsx
@@ -7,7 +7,7 @@ import { MultiServiceForm } from '@/components/multi-service-form/multi-service-
 import { createCustomAppMutation } from '@/api-client/@tanstack/react-query.gen';
 import { Input } from '@/components/ui/Input/Input';
 import type { TranslatableError } from '@/types/error.types';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { type } from 'arktype';
 import { useMultiServiceStore } from '@/stores/multiServiceStore';
 
@@ -18,7 +18,7 @@ export default () => {
   const navigate = useNavigate();
   const [appName, setAppName] = useState('');
   const [appNameError, setAppNameError] = useState<string>();
-  const { composeExtras } = useMultiServiceStore();
+  const { composeExtras, setComposeExtras } = useMultiServiceStore();
 
   const appNameSchema = type('string').narrow((name, ctx) => {
     if (name.length < 1) ctx.reject({ message: t('CUSTOM_APP_NAME_REQUIRED') });
@@ -39,6 +39,10 @@ export default () => {
       toast.error(t(error.message || 'CUSTOM_APP_CREATE_ERROR', { ...error.intlParams }));
     },
   });
+
+  useEffect(() => {
+    setComposeExtras({});
+  }, [setComposeExtras]);
 
   const onSubmit = (data: typeof dynamicComposeSchemaYaml.infer) => {
     const validation = appNameSchema(appName);

--- a/packages/frontend/src/stores/multiServiceStore.test.ts
+++ b/packages/frontend/src/stores/multiServiceStore.test.ts
@@ -1,0 +1,57 @@
+import { convertLegacyToYaml } from '@runtipi/common/schemas';
+import { parse } from 'yaml';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMultiServiceStore } from './multiServiceStore';
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe('multiServiceStore', () => {
+  beforeEach(() => {
+    useMultiServiceStore.getState().resetToDefaults();
+  });
+
+  it('preserves root-level volumes when YAML is saved and rebuilt from store state', () => {
+    useMultiServiceStore.getState().updateFromYaml(
+      parse(`x-runtipi:
+  schema_version: 2
+services:
+  dockhand:
+    image: fnsys/dockhand:latest
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - dockhand_data:/app/data
+    x-runtipi:
+      internal_port: "3000"
+      is_main: true
+volumes:
+  dockhand_data:
+`),
+    );
+
+    const { services, composeExtras } = useMultiServiceStore.getState();
+    const rebuiltYaml = {
+      ...convertLegacyToYaml({
+        schemaVersion: 2,
+        services: services.map(({ _id, ...service }) => service),
+      }),
+      ...composeExtras,
+    };
+
+    expect(rebuiltYaml).toMatchObject({
+      services: {
+        dockhand: {
+          image: 'fnsys/dockhand:latest',
+        },
+      },
+      volumes: {
+        dockhand_data: {},
+      },
+    });
+  });
+});

--- a/packages/frontend/src/stores/multiServiceStore.test.ts
+++ b/packages/frontend/src/stores/multiServiceStore.test.ts
@@ -1,5 +1,5 @@
 import { convertLegacyToYaml } from '@runtipi/common/schemas';
-import { parse } from 'yaml';
+import { parse, stringify } from 'yaml';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMultiServiceStore } from './multiServiceStore';
 
@@ -50,8 +50,11 @@ volumes:
         },
       },
       volumes: {
-        dockhand_data: {},
+        dockhand_data: null,
       },
     });
+    expect(stringify(rebuiltYaml, { nullStr: '' })).toContain(`volumes:
+  dockhand_data:
+`);
   });
 });

--- a/packages/frontend/src/stores/multiServiceStore.ts
+++ b/packages/frontend/src/stores/multiServiceStore.ts
@@ -14,6 +14,7 @@ interface ServiceWithId extends ServiceFormData {
 interface MultiServiceState {
   // State
   services: ServiceWithId[];
+  composeExtras: Record<string, unknown>;
   activeService: number | 'json';
   isDirty: boolean;
   error: string;
@@ -29,6 +30,7 @@ interface MultiServiceState {
   resetToDefaults: () => void;
   setIsDirty: (dirty: boolean) => void;
   setServices: (services: ServiceWithId[]) => void;
+  setComposeExtras: (composeExtras: Record<string, unknown>) => void;
 }
 
 const defaultService: ServiceFormData = {
@@ -57,10 +59,12 @@ function generateId(): string {
 
 export const useMultiServiceStore = create<MultiServiceState>()((set, get) => ({
   services: defaultServices,
+  composeExtras: {},
   activeService: 0,
   isDirty: false,
   error: '',
   setServices: (services: ServiceWithId[]) => set({ services: deepClean(services) as ServiceWithId[] }),
+  setComposeExtras: (composeExtras: Record<string, unknown>) => set({ composeExtras }),
   validate: (values: typeof dynamicComposeSchemaArk.infer) => {
     const res = dynamicComposeSchemaArk.omit('schemaVersion')(values);
 
@@ -186,6 +190,10 @@ export const useMultiServiceStore = create<MultiServiceState>()((set, get) => ({
   updateFromYaml: (yamlData: unknown) => {
     try {
       const legacy = convertYamlToLegacy(yamlData);
+      const composeExtras =
+        yamlData && typeof yamlData === 'object'
+          ? Object.fromEntries(Object.entries(yamlData).filter(([key]) => key !== 'services' && key !== 'x-runtipi'))
+          : {};
       const servicesWithIds = deepClean(
         legacy.services.map((service, index) => ({
           ...service,
@@ -201,7 +209,7 @@ export const useMultiServiceStore = create<MultiServiceState>()((set, get) => ({
         return;
       }
 
-      set({ services: servicesWithIds, isDirty: false });
+      set({ services: servicesWithIds, composeExtras, isDirty: false });
       toast.success('Services updated from YAML');
     } catch (err) {
       console.error(err);
@@ -215,6 +223,7 @@ export const useMultiServiceStore = create<MultiServiceState>()((set, get) => ({
       activeService: 0,
       error: '',
       isDirty: false,
+      composeExtras: {},
     }),
 
   setIsDirty: (dirty: boolean) => set({ isDirty: dirty }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loss of custom YAML configuration sections (e.g., `volumes`) when creating and editing multi-service applications; these sections are now properly preserved during save operations.

* **Tests**
  * Added test coverage for YAML configuration preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->