### PR TITLE
fix(queue): declare RPC queues as durable

### DIFF
--- a/packages/backend/src/modules/queue/queue.entity.ts
+++ b/packages/backend/src/modules/queue/queue.entity.ts
@@ -28,33 +28,40 @@ export class Queue<T extends ArkTypeSchema, R extends ArkTypeSchema<{ success: b
 
   public onEvent(callback: (data: Infer<T> & { eventId: string }, reply: (response: InferIn<R>) => Promise<void>) => Promise<void>) {
     try {
-      this.rabbit.createConsumer({ queue: this.queueName, concurrency: this.workers }, async (req, reply) => {
-        let rpcSuccess = false;
-        let rpcResultMessage = '';
+      this.rabbit.createConsumer(
+        {
+          queue: this.queueName,
+          concurrency: this.workers,
+          queueOptions: { autoDelete: false, durable: true },
+        },
+        async (req, reply) => {
+          let rpcSuccess = false;
+          let rpcResultMessage = '';
 
-        try {
-          await callback(req.body, reply);
-          rpcSuccess = true;
-          rpcResultMessage = 'RPC processed successfully.';
-        } catch (error) {
-          this.logger.error('Error in consumer callback:', error);
-          await reply({ success: false, message: (error as Error)?.message } as InferIn<R>);
-          rpcSuccess = false;
-          rpcResultMessage = error instanceof Error ? error.message : String(error);
-        } finally {
-          const eventToPublish = {
-            queueName: this.queueName,
-            requestData: req.body,
-            rpcStatus: rpcSuccess ? 'success' : 'failure',
-            rpcMessage: rpcResultMessage,
-            requestId: req.body.requestId,
-            timestamp: new Date().toISOString(),
-          };
+          try {
+            await callback(req.body, reply);
+            rpcSuccess = true;
+            rpcResultMessage = 'RPC processed successfully.';
+          } catch (error) {
+            this.logger.error('Error in consumer callback:', error);
+            await reply({ success: false, message: (error as Error)?.message } as InferIn<R>);
+            rpcSuccess = false;
+            rpcResultMessage = error instanceof Error ? error.message : String(error);
+          } finally {
+            const eventToPublish = {
+              queueName: this.queueName,
+              requestData: req.body,
+              rpcStatus: rpcSuccess ? 'success' : 'failure',
+              rpcMessage: rpcResultMessage,
+              requestId: req.body.requestId,
+              timestamp: new Date().toISOString(),
+            };
 
-          const routingKey = `rpc.${rpcSuccess ? 'processed' : 'error'}.${this.queueName}`;
-          await this.publisher.publish(routingKey, eventToPublish);
-        }
-      });
+            const routingKey = `rpc.${rpcSuccess ? 'processed' : 'error'}.${this.queueName}`;
+            await this.publisher.publish(routingKey, eventToPublish);
+          }
+        },
+      );
     } catch (error) {
       this.logger.error(`Failed to create consumer for queue ${this.queueName}:`, error);
       Sentry.captureException(error, { tags: { queueName: this.queueName, action: 'onEvent' } });

--- a/packages/backend/src/modules/queue/queue.factory.test.ts
+++ b/packages/backend/src/modules/queue/queue.factory.test.ts
@@ -1,0 +1,64 @@
+import { type } from 'arktype';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+import type { ConfigurationService } from '@/core/config/configuration.service';
+import type { LoggerService } from '@/core/logger/logger.service';
+import { QueueFactory } from './queue.factory';
+
+const rabbit = vi.hoisted(() => ({
+  createConsumer: vi.fn(),
+  createPublisher: vi.fn(() => ({ close: vi.fn() })),
+  createRPCClient: vi.fn(() => ({ send: vi.fn() })),
+  on: vi.fn((event: string, callback: () => void) => {
+    if (event === 'connection') {
+      callback();
+    }
+  }),
+  ready: true,
+}));
+
+vi.mock('rabbitmq-client', () => ({
+  Connection: vi.fn(function Connection() {
+    return rabbit;
+  }),
+}));
+
+describe('QueueFactory', () => {
+  const configurationService = mock<ConfigurationService>();
+  const loggerService = mock<LoggerService>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    configurationService.get.calledWith('queue').mockReturnValue({
+      host: 'localhost',
+      password: 'guest',
+      username: 'guest',
+    });
+  });
+
+  it('declares durable RPC and consumer queues', async () => {
+    const queueFactory = new QueueFactory(loggerService, configurationService);
+
+    const queue = await queueFactory.createQueue({
+      queueName: 'app-events-queue',
+      eventSchema: type({ event: 'string' }),
+    });
+
+    expect(rabbit.createRPCClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queues: [{ autoDelete: false, durable: true, queue: 'app-events-queue' }],
+      }),
+    );
+
+    queue.onEvent(vi.fn());
+
+    expect(rabbit.createConsumer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queue: 'app-events-queue',
+        queueOptions: { autoDelete: false, durable: true },
+      }),
+      expect.any(Function),
+    );
+  });
+});

--- a/packages/backend/src/modules/queue/queue.factory.ts
+++ b/packages/backend/src/modules/queue/queue.factory.ts
@@ -118,7 +118,7 @@ export class QueueFactory {
       timeout,
       confirm: true,
       maxAttempts: 3,
-      queues: [{ autoDelete: false, durable: false, queue: queueName }],
+      queues: [{ autoDelete: false, durable: true, queue: queueName }],
     });
 
     return new Queue(this.rabbit, rpcClient, publisher, queueName, workers, eventSchema, resultSchema, this.logger);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message queue reliability by ensuring queues persist across service restarts, preventing potential message loss

* **Tests**
  * Added comprehensive test coverage validating queue factory configuration and consumer initialization behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->