### PR TITLE
refactor: redact sensitive logs and disable swagger docs in prod

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -140,6 +140,7 @@ services:
       # Middlewares
       traefik.http.middlewares.runtipi.forwardauth.address: ${RUNTIPI_FORWARD_AUTH_URL:-http://runtipi:3000/api/auth/traefik}
       traefik.http.middlewares.runtipi.forwardauth.authRequestHeaders: Cookie
+      traefik.http.middlewares.runtipi.forwardauth.maxResponseBodySize: "8192"
 
 networks:
   tipi_main_network:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -136,6 +136,7 @@ services:
       # Middlewares
       traefik.http.middlewares.runtipi.forwardauth.address: ${RUNTIPI_FORWARD_AUTH_URL:-http://runtipi:3000/api/auth/traefik}
       traefik.http.middlewares.runtipi.forwardauth.authRequestHeaders: Cookie
+      traefik.http.middlewares.runtipi.forwardauth.maxResponseBodySize: "8192"
 
 networks:
   tipi_main_network:

--- a/packages/backend/src/core/logger/logger.service.ts
+++ b/packages/backend/src/core/logger/logger.service.ts
@@ -20,6 +20,9 @@ const printConsole = printf((info) => `${info.timestamp} - ${info.level} > ${inf
 const fileFormat = combine(format.uncolorize(), timestamp(), align(), printFile);
 const consoleFormat = combine(colorize(), timestamp({ format: 'HH:mm:ss' }), align(), printConsole);
 
+const REDACTED = '[REDACTED]';
+const SENSITIVE_KEY_PATTERN = /authorization|cookie|password|secret|token|private.?key|api.?key|dsn/i;
+
 type Transports = transports.ConsoleTransportInstance | transports.FileTransportInstance;
 
 /**
@@ -59,6 +62,33 @@ export const newLogger = (_: string, logsFolder: string, logLevel: LogLevel = LO
     exceptionHandlers,
     exitOnError: false,
   });
+};
+
+const redactSensitiveData: (value: unknown, visited?: WeakSet<object>) => unknown = (value, visited = new WeakSet<object>()) => {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitiveData(item, visited));
+  }
+
+  if ((value as object).constructor !== Object) {
+    return value;
+  }
+
+  if (visited.has(value)) {
+    return value;
+  }
+
+  visited.add(value);
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    redacted[key] = SENSITIVE_KEY_PATTERN.test(key) ? REDACTED : redactSensitiveData(nestedValue, visited);
+  }
+
+  return redacted;
 };
 
 @Injectable()
@@ -151,7 +181,7 @@ export class LoggerService {
       }
 
       if (typeof m === 'object') {
-        return JSON.stringify(m, null, 2);
+        return JSON.stringify(redactSensitiveData(m), null, 2);
       }
 
       return m;

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -13,6 +13,11 @@ import { APP_DIR } from './common/constants';
 import { generateSystemEnvFile } from './common/helpers/env-helpers';
 
 async function setupSwagger(app: INestApplication) {
+  const { NODE_ENV } = process.env;
+  if (NODE_ENV === 'production') {
+    return;
+  }
+
   const config = new DocumentBuilder()
     .setTitle('Runtipi API')
     .setDescription('API specs for Runtipi')
@@ -25,11 +30,8 @@ async function setupSwagger(app: INestApplication) {
   });
   SwaggerModule.setup('api/docs', app, document);
 
-  const { NODE_ENV } = process.env;
   // write the swagger.json file to the assets folder
-  if (NODE_ENV !== 'production') {
-    await fs.promises.writeFile(path.join(APP_DIR, 'packages', 'backend', 'src', 'swagger.json'), JSON.stringify(document, null, 2));
-  }
+  await fs.promises.writeFile(path.join(APP_DIR, 'packages', 'backend', 'src', 'swagger.json'), JSON.stringify(document, null, 2));
 }
 
 async function bootstrap() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sensitive data in logs is now automatically masked to prevent accidental exposure.

* **Bug Fixes**
  * API documentation endpoint is no longer accessible in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->